### PR TITLE
[#9]feat : 책검색 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // Apache Commons Lang
     implementation 'org.apache.commons:commons-lang3:3.0'
     implementation 'commons-validator:commons-validator:1.7'
@@ -50,6 +52,8 @@ dependencies {
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
     // mapstruct
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+
     // jwt
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/src/main/java/com/dadok/gaerval/domain/book/api/BookController.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/api/BookController.java
@@ -1,0 +1,37 @@
+package com.dadok.gaerval.domain.book.api;
+
+import static org.springframework.http.MediaType.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dadok.gaerval.domain.book.dto.response.BookResponses;
+import com.dadok.gaerval.domain.book.service.BookService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/books")
+@RestController
+@RequiredArgsConstructor
+public class BookController {
+
+	private final BookService bookService;
+
+	/**
+	 * <pre>
+	 *     검색어를 입력받아 도서 목록을 외부 API로부터 받아온다.
+	 * </pre>
+	 *
+	 * @param query 검색어
+	 * @return status : ok
+	 */
+	@GetMapping(produces = APPLICATION_JSON_VALUE)
+	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+	public ResponseEntity<BookResponses> findBooksByQuery(@RequestParam(name = "query") String query) {
+		return ResponseEntity.ok().body(bookService.findAllByKeyword(query));
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/converter/BookMapper.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/converter/BookMapper.java
@@ -1,0 +1,13 @@
+package com.dadok.gaerval.domain.book.converter;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+import com.dadok.gaerval.domain.book.dto.response.SearchBookResponse;
+import com.dadok.gaerval.domain.book.entity.Book;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface BookMapper {
+
+	SearchBookResponse entityToSearchBookResponse(Book book);
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/dto/request/SearchTarget.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/dto/request/SearchTarget.java
@@ -1,0 +1,28 @@
+package com.dadok.gaerval.domain.book.dto.request;
+
+import com.dadok.gaerval.global.common.EnumType;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SearchTarget implements EnumType {
+
+	TITLE("title","책 제목"),
+	PERSON("person", "인명"),
+	PUBLISHER("publisher","출판사"),
+	ISBN("isbn","isbn");
+
+	private final String name;
+	private final String description;
+
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/dto/request/SortingPolicy.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/dto/request/SortingPolicy.java
@@ -1,0 +1,25 @@
+package com.dadok.gaerval.domain.book.dto.request;
+
+import com.dadok.gaerval.global.common.EnumType;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SortingPolicy implements EnumType {
+
+	ACCURACY("accuracy","정확도 순"),
+	LATEST("latest","최신순");
+
+	private final String name;
+	private final String description;
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	@Override
+	public String getDescription() {
+		return this.description;
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/dto/response/BookResponses.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/dto/response/BookResponses.java
@@ -1,0 +1,6 @@
+package com.dadok.gaerval.domain.book.dto.response;
+
+import java.util.List;
+
+public record BookResponses (List<SearchBookResponse> searchBookResponseList){
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/dto/response/OriginalBookData.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/dto/response/OriginalBookData.java
@@ -1,0 +1,62 @@
+package com.dadok.gaerval.domain.book.dto.response;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public record OriginalBookData(
+	String contents,
+	String datetime,
+	String isbn,
+	Long price,
+	String publisher,
+	Long salePrice,
+	String status,
+	String thumbnail,
+	String url,
+	String[] authors,
+	String[] translators
+	) {
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		OriginalBookData that = (OriginalBookData) o;
+		return Objects.equals(contents, that.contents) &&
+			Objects.equals(datetime, that.datetime) &&
+			Objects.equals(isbn, that.isbn) &&
+			Objects.equals(price, that.price) &&
+			Objects.equals(publisher, that.publisher) &&
+			Objects.equals(salePrice, that.salePrice) &&
+			Objects.equals(status, that.status) &&
+			Objects.equals(thumbnail, that.thumbnail) &&
+			Objects.equals(url, that.url) &&
+			Arrays.equals(authors, that.authors) &&
+			Arrays.equals(translators, that.translators);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Objects.hash(contents, datetime, isbn, price, publisher, salePrice, status, thumbnail, url);
+		result = 31 * result + Arrays.hashCode(authors);
+		result = 31 * result + Arrays.hashCode(translators);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "OriginalBookData{" +
+			"contents='" + contents + '\'' +
+			", dateTime='" + datetime + '\'' +
+			", isbn='" + isbn + '\'' +
+			", price=" + price +
+			", publisher='" + publisher + '\'' +
+			", salePrice=" + salePrice +
+			", status='" + status + '\'' +
+			", thumbnail='" + thumbnail + '\'' +
+			", url='" + url + '\'' +
+			", authors=" + Arrays.toString(authors) +
+			", translators=" + Arrays.toString(translators) +
+			'}';
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/dto/response/SearchBookResponse.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/dto/response/SearchBookResponse.java
@@ -1,0 +1,5 @@
+package com.dadok.gaerval.domain.book.dto.response;
+
+public record SearchBookResponse(String title, String author, String isbn, String contents, String url,
+								 String imageUrl, String apiProvider, String publisher) {
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/entity/Book.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/entity/Book.java
@@ -1,15 +1,14 @@
 package com.dadok.gaerval.domain.book.entity;
 
+import static com.dadok.gaerval.global.util.CommonValidator.*;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Lob;
 import javax.persistence.Table;
 import javax.validation.constraints.Size;
-
-import com.mysema.commons.lang.Assert;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -37,7 +36,8 @@ public class Book {
 	@Size(min = 10, max = 20)
 	private String isbn;
 
-	@Column(nullable = false, columnDefinition = "VARCHAR(2000)")
+	@Column(nullable = false)
+	@Size(min = 1, max = 2000)
 	private String contents;
 
 	@Column(nullable = false)
@@ -55,8 +55,11 @@ public class Book {
 	@Column(length = 20, nullable = false)
 	private String apiProvider;
 
+	@Column(length = 20, nullable = false)
+	private String publisher;
+
 	protected Book(String title, String author, String isbn, String contents, String url,
-		String imageUrl, String apiProvider) {
+		String imageUrl, String apiProvider, String publisher) {
 
 		this.title = title;
 		this.author = author;
@@ -66,71 +69,38 @@ public class Book {
 		this.imageUrl = imageUrl;
 		this.apiProvider = apiProvider;
 		this.isDeleted = false;
+		this.publisher = publisher;
 
-		validateTitle(title);
-		validateAuthor(author);
-		validateIsbn(isbn);
-		validateContents(contents);
-		validateUrl(url);
-		validateImageUrl(imageUrl);
-		validateApiProvider(apiProvider);
+		validateLengthInRange(title, 1, 500, "책 제목");
+		validateLengthInRange(author, 1, 255, "책 저자");
+		validateLengthInRange(isbn, 10, 20, "ISBN");
+		validateLengthInRange(contents, 1, 2000, "책 소개");
+		validateLengthInRange(url, 0, 2083, "URL");
+		validateLengthInRange(imageUrl, 0, 2083, "이미지 URL");
+		validateLengthInRange(apiProvider, 0, 20, "API 제공자");
+		validateLengthInRange(publisher, 1, 20, "출판사");
 	}
 
 	protected Book(String title, String author, String isbn, String contents, String url,
-		String imageUrl, String imageKey, String apiProvider) {
-		this(title, author, isbn, contents, url, imageUrl, apiProvider);
+		String imageUrl, String imageKey, String apiProvider, String publisher) {
+		this(title, author, isbn, contents, url, imageUrl, apiProvider, publisher);
 		this.imageKey = imageKey;
-
-		validateImageKey(imageKey);
-
+		validateLengthInRange(imageKey, 0, 500, "이미지 키");
 	}
 
 	public static Book create(String title, String author, String isbn, String contents, String url,
-		String imageUrl, String apiProvider) {
+		String imageUrl, String apiProvider, String publisher) {
 		return new Book(title, author, isbn, contents, url,
-			imageUrl, apiProvider);
+			imageUrl, apiProvider, publisher);
 	}
-
 
 	public static Book create(String title, String author, String isbn, String contents, String url,
-		String imageUrl, String imageKey, String apiProvider) {
+		String imageUrl, String imageKey, String apiProvider, String publisher) {
 		return new Book(title, author, isbn, contents, url,
-			imageUrl, imageKey, apiProvider);
+			imageUrl, imageKey, apiProvider, publisher);
 	}
 
-	private void validateTitle(String title) {
-		Assert.isTrue(title != null && title.length() >= 1 && title.length() <= 500, "책 제목의 길이는 1이상 500 이하 입니다.");
-	}
-
-	private void validateAuthor(String author) {
-		Assert.isTrue(author != null && author.length() >= 1 && author.length() <= 500, "책 저자의 길이는 1이상 255 이하 입니다.");
-	}
-
-	private void validateIsbn(String isbn) {
-		Assert.isTrue(isbn != null && isbn.length() >= 10 && isbn.length() <= 20, "ISBN의 길이는 10 이상 20 이하입니다.");
-	}
-
-	private void validateContents(String contents) {
-		Assert.isTrue(contents != null && contents.length() >= 1, "책 소개의 길이는 1 이상입니다.");
-	}
-
-	private void validateUrl(String url) {
-		Assert.isTrue(url != null && url.length() <= 2083, "URL의 길이는 2083 이하여야 합니다.");
-	}
-
-	private void validateImageUrl(String imageUrl) {
-		Assert.isTrue(imageUrl != null && imageUrl.length() <= 2083, "이미지 URL의 길이는 2083 이하여야 합니다.");
-	}
-
-	private void validateImageKey(String imageKey) {
-		Assert.isTrue(imageKey != null && imageKey.length() <= 500, "이미지 키의 길이는 500 이하여야 합니다.");
-	}
-
-	private void validateApiProvider(String apiProvider) {
-		Assert.isTrue(apiProvider != null && apiProvider.length() <= 20, "API 제공자의 길이는 20 이하여야 합니다.");
-	}
-
-	public void setDeleted(boolean deleted) {
+	public void changeDeleted(boolean deleted) {
 		isDeleted = deleted;
 	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/book/exception/InvalidBookDataException.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/exception/InvalidBookDataException.java
@@ -1,0 +1,21 @@
+package com.dadok.gaerval.domain.book.exception;
+
+import com.dadok.gaerval.global.error.ErrorCode;
+import com.dadok.gaerval.global.error.exception.BusinessException;
+
+import lombok.Getter;
+
+public class InvalidBookDataException extends BusinessException {
+	@Getter
+	private final ErrorCode errorCode;
+
+	public InvalidBookDataException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public InvalidBookDataException(ErrorCode errorCode, Throwable cause) {
+		super(errorCode.getMessage(), cause);
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/repository/BookRepository.java
@@ -1,0 +1,11 @@
+package com.dadok.gaerval.domain.book.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.dadok.gaerval.domain.book.entity.Book;
+
+
+@Repository
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/service/BookService.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/BookService.java
@@ -3,11 +3,12 @@ package com.dadok.gaerval.domain.book.service;
 import java.util.Optional;
 
 import com.dadok.gaerval.domain.book.dto.request.BookCreateRequest;
+import com.dadok.gaerval.domain.book.dto.response.BookResponses;
 import com.dadok.gaerval.domain.book.entity.Book;
 
 public interface BookService {
-	//
-	// BookResponses findAllByKeyword(String keyword, Pageable pageable, );
+
+	BookResponses findAllByKeyword(String keyword);
 
 	Book createBook(BookCreateRequest bookCreateRequest);
 

--- a/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
@@ -1,14 +1,78 @@
 package com.dadok.gaerval.domain.book.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import com.dadok.gaerval.domain.book.converter.BookMapper;
 import com.dadok.gaerval.domain.book.dto.request.BookCreateRequest;
+import com.dadok.gaerval.domain.book.dto.request.SortingPolicy;
+import com.dadok.gaerval.domain.book.dto.response.BookResponses;
+import com.dadok.gaerval.domain.book.dto.response.SearchBookResponse;
 import com.dadok.gaerval.domain.book.entity.Book;
+import com.dadok.gaerval.domain.book.exception.InvalidBookDataException;
+import com.dadok.gaerval.domain.book.repository.BookRepository;
+import com.dadok.gaerval.global.config.security.AuthProvider;
+import com.dadok.gaerval.global.error.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
 
 @Service
+@Slf4j
+@RequiredArgsConstructor
 public class DefaultBookService implements BookService {
+
+	private final WebClient webClient;
+	private final ObjectMapper objectMapper;
+	private final BookRepository bookRepository;
+	private final BookMapper bookMapper;
+
+	@Override
+	@Transactional
+	public BookResponses findAllByKeyword(String keyword) {
+		// TODO 페이징 처리
+		Flux<String> resultFlux = searchBooks(keyword, 1, 10, SortingPolicy.ACCURACY.getName());
+		List<SearchBookResponse> searchBookResponseList = new ArrayList<>();
+		try {
+			JsonNode jsonNode = objectMapper.readTree(resultFlux.toStream().findFirst().orElse(""));
+			log.info(jsonNode.toPrettyString());
+
+			Optional<JsonNode> documents = Optional.of(jsonNode.get("documents"));
+
+			documents.ifPresent(docs -> docs.forEach(document -> {
+				String title = document.get("title").asText();
+				List<String> allAuthors = new ArrayList<>();
+				document.get("authors").forEach(authorNode -> allAuthors.add(authorNode.asText()));
+				String isbn = document.get("isbn").asText().split(" ")[1];
+				String contents = document.get("contents").asText();
+				String url = document.get("url").asText();
+				String imageUrl = document.get("thumbnail").asText();
+				String apiProvider = AuthProvider.KAKAO.getName();
+				String publisher = document.get("publisher").asText();
+
+				Book book = Book.create(title, String.join(",", allAuthors), isbn, contents, url, imageUrl, apiProvider,
+					publisher);
+				searchBookResponseList.add(bookMapper.entityToSearchBookResponse(book));
+				// TODO 저장정책
+				// bookRepository.save(book);
+			}));
+
+		} catch (JsonProcessingException e) {
+			throw new InvalidBookDataException(ErrorCode.BOOK_DATA_INVALID);
+		}
+		return new BookResponses(searchBookResponseList);
+	}
+
 	@Override
 	public Book createBook(BookCreateRequest bookCreateRequest) {
 		return null;
@@ -29,4 +93,16 @@ public class DefaultBookService implements BookService {
 		return Optional.empty();
 	}
 
+	private Flux<String> searchBooks(String query, int page, int size, String sort) {
+		return webClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.queryParam("query", query)
+				.queryParam("page", page)
+				.queryParam("size", size)
+				.queryParam("sort", sort)
+				.build())
+			.accept(MediaType.APPLICATION_JSON)
+			.retrieve()
+			.bodyToFlux(String.class);
+	}
 }

--- a/src/main/java/com/dadok/gaerval/global/config/webclient/WebClientConfig.java
+++ b/src/main/java/com/dadok/gaerval/global/config/webclient/WebClientConfig.java
@@ -1,0 +1,37 @@
+package com.dadok.gaerval.global.config.webclient;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorResourceFactory;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Configuration
+@RequiredArgsConstructor
+public class WebClientConfig {
+
+	private final WebClientProperties webClientProperties;
+
+	@Bean
+	public ReactorResourceFactory resourceFactory() {
+		ReactorResourceFactory factory = new ReactorResourceFactory();
+		factory.setUseGlobalResources(false);
+		return factory;
+	}
+
+	@Bean
+	public WebClient webClient(){
+		return WebClient.builder()
+			.baseUrl(webClientProperties.getBaseUri())
+			.defaultHeader(HttpHeaders.AUTHORIZATION,
+				String.format("%s %s", webClientProperties.getScheme(), webClientProperties.getApiKey()))
+			.build();
+	}
+
+
+
+}

--- a/src/main/java/com/dadok/gaerval/global/config/webclient/WebClientProperties.java
+++ b/src/main/java/com/dadok/gaerval/global/config/webclient/WebClientProperties.java
@@ -1,0 +1,23 @@
+package com.dadok.gaerval.global.config.webclient;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import lombok.Getter;
+
+@Getter
+@ConstructorBinding
+@ConfigurationProperties(prefix = "search-api-provider")
+public class WebClientProperties {
+
+	private final String apiKey;
+	private final String scheme;
+	private final String baseUri;
+
+	public WebClientProperties(String scheme, String baseUri, String apiKey) {
+		this.scheme = scheme;
+		this.baseUri = baseUri;
+		this.apiKey = apiKey;
+	}
+
+}

--- a/src/main/java/com/dadok/gaerval/global/error/ErrorCode.java
+++ b/src/main/java/com/dadok/gaerval/global/error/ErrorCode.java
@@ -18,7 +18,10 @@ public enum ErrorCode {
 
 	// Bookshelf
 	ALREADY_CONTAIN_BOOKSHELF_ITEM(HttpStatus.BAD_REQUEST, "S001", "이미 책장에 포함된 아아템입니다."),
-	BOOKSHELF_USER_NOT_MATCHED(HttpStatus.FORBIDDEN, "S002", "해당 책장에 올바르지 않은 사용자 접근입니다.");
+	BOOKSHELF_USER_NOT_MATCHED(HttpStatus.UNAUTHORIZED, "S002", "해당 책장에 올바르지 않은 사용자 접근입니다."),
+
+	// Book
+	BOOK_DATA_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "B001", "잘못된 도서 데이터 형식입니다.");
 
 	private final HttpStatus status;
 

--- a/src/main/resources/application-api.yml
+++ b/src/main/resources/application-api.yml
@@ -1,0 +1,4 @@
+search-api-provider:
+    api-key: ${KAKAO_CLIENT_ID}
+    scheme: ${KAKAO_SCHEME}
+    base-uri: ${KAKAO_BOOK_BASE_URI}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
       - db
       - security
       - aws
+      - api
     active: ${SPRING_PROFILES_ACTIVE}
 
   config:

--- a/src/test/java/com/dadok/gaerval/domain/book/entity/BookTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/entity/BookTest.java
@@ -1,11 +1,14 @@
 package com.dadok.gaerval.domain.book.entity;
 
+
+import com.dadok.gaerval.global.error.exception.InvalidArgumentException;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.dadok.gaerval.testutil.BookObjectProvider;
+
 
 class BookTest {
 
@@ -22,7 +25,9 @@ class BookTest {
 		String url = "https://search.daum.net/search?w=bookpage&bookId=1467038&q=%EB%AF%B8%EC%9B%80%EB%B0%9B%EC%9D%84+%EC%9A%A9%EA%B8%B0";
 		String imageUrl = "https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F1467038";
 		String apiProvider = "kakao";
-		Book book = Book.create(title, author, isbn, contents, url, imageUrl, apiProvider);
+		String publisher = "인플루엔셜";
+
+		Book book = Book.create(title, author, isbn, contents, url, imageUrl, apiProvider, publisher);
 
 		// When Then
 		assertEquals(title, book.getTitle());
@@ -48,7 +53,9 @@ class BookTest {
 		String imageUrl = "https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F1467038";
 		String apiProvider = "kakao";
 		String imageKey = "687f74fd-a612-4ec9-9ae5-8f7b7fe8e80f/photo-1606787364406-a3cdf06c6d0c.jpeg";
-		Book book = Book.create(title, author, isbn, contents, url, imageUrl, imageKey, apiProvider);
+		String publisher = "인플루엔셜";
+
+		Book book = Book.create(title, author, isbn, contents, url, imageUrl, imageKey, apiProvider, publisher);
 		// When Then
 		assertEquals(title, book.getTitle());
 		assertEquals(author, book.getAuthor());
@@ -71,9 +78,10 @@ class BookTest {
 		String url = "https://migu.world";
 		String imageUrl = "";
 		String apiProvider = "kakao";
+		String publisher = "인플루엔셜";
 
 		// When Then
-		assertThrows(IllegalArgumentException.class, () -> new Book( emptyTitle, author, exceededIsbn, emptyContents, url, imageUrl, apiProvider));
+		assertThrows(InvalidArgumentException.class, () -> new Book( emptyTitle, author, exceededIsbn, emptyContents, url, imageUrl, apiProvider, publisher));
 	}
 
 
@@ -83,7 +91,7 @@ class BookTest {
 		// Given
 		Book book = BookObjectProvider.createRequiredFieldBook();
 		// When
-		book.setDeleted(true);
+		book.changeDeleted(true);
 		// Then
 		assertTrue(book.isDeleted());
 	}

--- a/src/test/java/com/dadok/gaerval/testutil/BookObjectProvider.java
+++ b/src/test/java/com/dadok/gaerval/testutil/BookObjectProvider.java
@@ -6,18 +6,27 @@ import com.dadok.gaerval.domain.book.entity.Book;
 
 public class BookObjectProvider {
 
-	private static final String title = "미움받을 용기";
-	private static final String author = "기시미 이치로, 고가 후미타케";
-	private static final String isbn = "9788996991342";
-	private static final String contents = "인간은 변할 수 있고, 누구나 행복해 질 수 있다. 단 그러기 위해서는 ‘용기’가 필요하다고 말한 철학자가 있다.";
-	private static final String url = "https://search.daum.net/search?w=bookpage&bookId=1467038&q=%EB%AF%B8%EC%9B%80%EB%B0%9B%EC%9D%84+%EC%9A%A9%EA%B8%B0";
-	private static final String imageUrl = "https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F1467038";
-	private static final String apiProvider = "kakao";
+	public static final String title = "미움받을 용기";
+	public static final String author = "기시미 이치로, 고가 후미타케";
+	public static final String isbn = "9788996991342";
+	public static final String contents = "인간은 변할 수 있고, 누구나 행복해 질 수 있다. 단 그러기 위해서는 ‘용기’가 필요하다고 말한 철학자가 있다.";
+	public static final String url = "https://search.daum.net/search?w=bookpage&bookId=1467038&q=%EB%AF%B8%EC%9B%80%EB%B0%9B%EC%9D%84+%EC%9A%A9%EA%B8%B0";
+	public static final String imageUrl = "https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F1467038";
+	public static final String apiProvider = "kakao";
+	public static final String imageKey = "687f74fd-a612-4ec9-9ae5-8f7b7fe8e80f/photo-1606787364406-a3cdf06c6d0c.jpeg";
+	public static final String publisher = "인플루엔셜";
+	public static final long userId = 123L;
 
 	public static Book createRequiredFieldBook() {
 
-		Book book = Book.create(title, author, isbn, contents, url, imageUrl, apiProvider);
-		ReflectionTestUtils.setField(book, "id", 1L);
+		Book book = Book.create(title, author, isbn, contents, url, imageUrl, apiProvider, publisher);
+		ReflectionTestUtils.setField(book, "id", userId);
+		return book;
+	}
+
+	public static Book createAllFieldBook() {
+		Book book = Book.create(title, author, isbn, contents, url, imageUrl, imageKey ,apiProvider, publisher);
+		ReflectionTestUtils.setField(book, "id", userId);
 		return book;
 	}
 }


### PR DESCRIPTION
🍀 목적
- 검색어를 통해 카카오 검색 API로부터 도서를 받아오기 위함
🌹 추가사항
- 검색어 기반 엔드포인트 구현
☕ 변경사항
- BookObjectProvider 모든 필드 예시 추가
- Book 엔티티 요구사항 변경 반영(출판사)
❓ pr 포인트
- 테스트는 계속 작성하겠습니다..
- json parsing을 위해 jackson을 사용했습니다. 코드길이를 더 줄이기 위해 OriginalBookData를 사용해 리팩터링할 예정입니다.
- API 테스트는 잠시 /books/** 권한을 풀어주고 진행했습니다.
- WebClient를 Bean으로 사용하는 방식이 보편적이라 Bean으로 올렸습니다.
- 다수의 데이터를 받아올 예정이므로 Mono가 아닌 Flux를 사용했습니다.
📢 Help
webclient와 관련된 의존성인 spring-webflux 와 reactor-core 만 남겨두고 나머지 webflux group 의존성을 모두 exclude 했더니 No suitable default ClientHttpConnector found 에러가 발생해 일단 webflux starter 의존성을 가져온 상태입니다.
