### PR TITLE
[#60] Web Client 추상화, 수신 데이터 전처리 

### DIFF
--- a/src/main/java/com/dadok/gaerval/domain/book/entity/Book.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/entity/Book.java
@@ -17,11 +17,13 @@ import com.dadok.gaerval.global.common.JacocoExcludeGenerated;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Table(name = "books")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class Book {
 
 	@Id

--- a/src/main/java/com/dadok/gaerval/domain/book/service/BookDataProcessor.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/BookDataProcessor.java
@@ -12,7 +12,7 @@ public class BookDataProcessor {
 	static Book process(String title, List<String> authors, String contents, String isbn, String url, String imageUrl,
 		String publisher) {
 
-		if (StringUtils.isEmpty(title)) {
+		if (StringUtils.isBlank(title)) {
 			title = "책 제목 미상";
 		}
 
@@ -21,7 +21,7 @@ public class BookDataProcessor {
 			authorsString = "저자 미상";
 		}
 
-		if (StringUtils.isEmpty(contents)) {
+		if (StringUtils.isBlank(contents)) {
 			contents = "책 소개 미상";
 		} else {
 			if (contents.length() >= 1999)
@@ -30,7 +30,7 @@ public class BookDataProcessor {
 
 		isbn = isbn.contains(" ") ? isbn.split(" ")[1] : isbn;
 
-		if (StringUtils.isEmpty(publisher)) {
+		if (StringUtils.isBlank(publisher)) {
 			publisher = "출판사 미상";
 		}
 

--- a/src/main/java/com/dadok/gaerval/domain/book/service/BookDataProcessor.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/BookDataProcessor.java
@@ -22,7 +22,7 @@ public class BookDataProcessor {
 		}
 
 		if (StringUtils.isEmpty(contents)) {
-			contents = "콘텐츠 미상";
+			contents = "책 소개 미상";
 		} else {
 			if (contents.length() >= 1999)
 				contents = contents.substring(0, 1998);

--- a/src/main/java/com/dadok/gaerval/domain/book/service/BookDataProcessor.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/BookDataProcessor.java
@@ -1,0 +1,42 @@
+package com.dadok.gaerval.domain.book.service;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.dadok.gaerval.domain.book.entity.Book;
+import com.dadok.gaerval.global.config.security.AuthProvider;
+
+public class BookDataProcessor {
+
+	static Book process(String title, List<String> authors, String contents, String isbn, String url, String imageUrl,
+		String publisher) {
+
+		if (StringUtils.isEmpty(title)) {
+			title = "책 제목 미상";
+		}
+
+		String authorsString = String.join(",", authors);
+		if (authors.isEmpty()) {
+			authorsString = "저자 미상";
+		}
+
+		if (StringUtils.isEmpty(contents)) {
+			contents = "콘텐츠 미상";
+		} else {
+			if (contents.length() >= 1999)
+				contents = contents.substring(0, 1998);
+		}
+
+		isbn = isbn.contains(" ") ? isbn.split(" ")[1] : isbn;
+
+		if (StringUtils.isEmpty(publisher)) {
+			publisher = "출판사 미상";
+		}
+
+		return Book.create(title, authorsString, isbn,
+			contents, url, imageUrl, AuthProvider.KAKAO.getName(),
+			publisher);
+
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
@@ -49,11 +49,11 @@ public class DefaultBookService implements BookService {
 			return new BookResponses(Collections.emptyList());
 		}
 
-		Flux<String> resultFlux = externalBookApiOperations.searchBooks(keyword, 1, 10, SortingPolicy.ACCURACY.getName());
+		String result = externalBookApiOperations.searchBooks(keyword, 1, 10, SortingPolicy.ACCURACY.getName());
 
 		List<SearchBookResponse> searchBookResponseList = new ArrayList<>();
 		try {
-			JsonNode jsonNode = objectMapper.readTree(resultFlux.toStream().findFirst().orElse(""));
+			JsonNode jsonNode = objectMapper.readTree(result);
 			log.info("[DefaultBookService]-[findAllByKeyword] received data : {}", jsonNode.toPrettyString());
 
 			Optional<JsonNode> documents = Optional.of(jsonNode.get("documents"));

--- a/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
@@ -1,13 +1,15 @@
 package com.dadok.gaerval.domain.book.service;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.dadok.gaerval.domain.book.converter.BookMapper;
@@ -19,7 +21,6 @@ import com.dadok.gaerval.domain.book.dto.response.SearchBookResponse;
 import com.dadok.gaerval.domain.book.entity.Book;
 import com.dadok.gaerval.domain.book.exception.InvalidBookDataException;
 import com.dadok.gaerval.domain.book.repository.BookRepository;
-import com.dadok.gaerval.global.config.security.AuthProvider;
 import com.dadok.gaerval.global.error.ErrorCode;
 import com.dadok.gaerval.global.error.exception.ResourceNotfoundException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -45,50 +46,34 @@ public class DefaultBookService implements BookService {
 	public BookResponses findAllByKeyword(String keyword) {
 		// TODO 페이징 처리
 
-		if (!StringUtils.hasText(keyword)) {
+		if (StringUtils.isBlank(keyword) || !StringUtils.isAlphanumericSpace(keyword)) {
+			log.info("[DefaultBookService]-[findAllByKeyword] invalid keyword : {}", keyword);
 			return new BookResponses(Collections.emptyList());
 		}
-
-		System.out.println("search keyword : " + keyword);
 
 		Flux<String> resultFlux = searchBooks(keyword, 1, 10, SortingPolicy.ACCURACY.getName());
 
 		List<SearchBookResponse> searchBookResponseList = new ArrayList<>();
 		try {
 			JsonNode jsonNode = objectMapper.readTree(resultFlux.toStream().findFirst().orElse(""));
-			log.info(jsonNode.toPrettyString());
+			log.info("[DefaultBookService]-[findAllByKeyword] received data : {}", jsonNode.toPrettyString());
 
 			Optional<JsonNode> documents = Optional.of(jsonNode.get("documents"));
 
 			documents.ifPresent(docs -> docs.forEach(document -> {
-				String title = document.get("title").asText();
 				List<String> allAuthors = new ArrayList<>();
 				document.get("authors").forEach(authorNode -> allAuthors.add(authorNode.asText()));
-				String isbn = document.get("isbn").asText().split(" ")[1];
-				String contents = document.get("contents").asText();
-				String url = document.get("url").asText();
-				String imageUrl = document.get("thumbnail").asText();
-				String apiProvider = AuthProvider.KAKAO.getName();
-				String publisher = document.get("publisher").asText();
 
-				String processingContents;
+				Book processedBook = BookDataProcessor.process(document.get("title").asText(),
+					allAuthors,
+					document.get("contents").asText(),
+					document.get("isbn").asText(),
+					document.get("url").asText(),
+					document.get("thumbnail").asText(),
+					document.get("publisher").asText()
+				);
 
-				if (!StringUtils.hasText(contents) || contents.length() == 0) {
-					processingContents = "콘텐츠가 없습니다.";
-				} else {
-					if (contents.length() >= 1999)
-						processingContents = contents.substring(0, 1998);
-					else
-						processingContents = contents;
-				}
-
-				Book book = Book.create(title, String.join(",", allAuthors), isbn,
-					processingContents, url, imageUrl, apiProvider,
-					publisher);
-
-				searchBookResponseList.add(bookMapper.entityToSearchBookResponse(book));
-				// TODO 저장정책
-				// bookRepository.save(book);
+				searchBookResponseList.add(bookMapper.entityToSearchBookResponse(processedBook));
 			}));
 
 		} catch (JsonProcessingException e) {
@@ -130,7 +115,7 @@ public class DefaultBookService implements BookService {
 	@Override
 	@Transactional(readOnly = true)
 	public Book getById(Long bookId) {
-		return bookRepository.findById(bookId).orElseThrow(()-> new ResourceNotfoundException(Book.class));
+		return bookRepository.findById(bookId).orElseThrow(() -> new ResourceNotfoundException(Book.class));
 	}
 
 	@Override
@@ -159,7 +144,10 @@ public class DefaultBookService implements BookService {
 				.queryParam("size", size)
 				.queryParam("sort", sort)
 				.build())
+			.acceptCharset(StandardCharsets.UTF_8)
+			.accept(MediaType.APPLICATION_JSON)
 			.retrieve()
 			.bodyToFlux(String.class);
 	}
+
 }

--- a/src/main/java/com/dadok/gaerval/global/config/externalapi/ExternalBookApiOperations.java
+++ b/src/main/java/com/dadok/gaerval/global/config/externalapi/ExternalBookApiOperations.java
@@ -1,0 +1,12 @@
+package com.dadok.gaerval.global.config.externalapi;
+
+import com.dadok.gaerval.domain.book.dto.request.SearchTarget;
+
+import reactor.core.publisher.Flux;
+
+public interface ExternalBookApiOperations {
+	Flux<String> searchBooks(String query, int page, int size, String sort);
+
+	Flux<String> searchBooksWithTargetRestriction(String query, SearchTarget searchTarget, int page, int size,
+		String sort);
+}

--- a/src/main/java/com/dadok/gaerval/global/config/externalapi/ExternalBookApiOperations.java
+++ b/src/main/java/com/dadok/gaerval/global/config/externalapi/ExternalBookApiOperations.java
@@ -5,8 +5,8 @@ import com.dadok.gaerval.domain.book.dto.request.SearchTarget;
 import reactor.core.publisher.Flux;
 
 public interface ExternalBookApiOperations {
-	Flux<String> searchBooks(String query, int page, int size, String sort);
+	String searchBooks(String query, int page, int size, String sort);
 
-	Flux<String> searchBooksWithTargetRestriction(String query, SearchTarget searchTarget, int page, int size,
+	String searchBooksWithTargetRestriction(String query, SearchTarget searchTarget, int page, int size,
 		String sort);
 }

--- a/src/main/java/com/dadok/gaerval/global/config/externalapi/WebClientBookApiOperations.java
+++ b/src/main/java/com/dadok/gaerval/global/config/externalapi/WebClientBookApiOperations.java
@@ -9,16 +9,15 @@ import org.springframework.web.reactive.function.client.WebClient;
 import com.dadok.gaerval.domain.book.dto.request.SearchTarget;
 
 import lombok.RequiredArgsConstructor;
-import reactor.core.publisher.Flux;
 
 @Component
 @RequiredArgsConstructor
-public class WebClientBookApiOperations implements ExternalBookApiOperations{
+public class WebClientBookApiOperations implements ExternalBookApiOperations {
 
 	private final WebClient webClient;
 
 	@Override
-	public Flux<String> searchBooks(String query, int page, int size, String sort) {
+	public String searchBooks(String query, int page, int size, String sort) {
 		return webClient.get()
 			.uri(uriBuilder -> uriBuilder
 				.queryParam("query", query)
@@ -29,11 +28,13 @@ public class WebClientBookApiOperations implements ExternalBookApiOperations{
 			.acceptCharset(StandardCharsets.UTF_8)
 			.accept(MediaType.APPLICATION_JSON)
 			.retrieve()
-			.bodyToFlux(String.class);
+			.bodyToFlux(String.class)
+			.toStream().findFirst().orElse("")
+			;
 	}
 
 	@Override
-	public Flux<String> searchBooksWithTargetRestriction(String query, SearchTarget searchTarget, int page, int size,
+	public String searchBooksWithTargetRestriction(String query, SearchTarget searchTarget, int page, int size,
 		String sort) {
 		return webClient.get()
 			.uri(uriBuilder -> uriBuilder
@@ -46,6 +47,7 @@ public class WebClientBookApiOperations implements ExternalBookApiOperations{
 			.acceptCharset(StandardCharsets.UTF_8)
 			.accept(MediaType.APPLICATION_JSON)
 			.retrieve()
-			.bodyToFlux(String.class);
+			.bodyToFlux(String.class)
+			.toStream().findFirst().orElse("");
 	}
 }

--- a/src/main/java/com/dadok/gaerval/global/config/externalapi/WebClientBookApiOperations.java
+++ b/src/main/java/com/dadok/gaerval/global/config/externalapi/WebClientBookApiOperations.java
@@ -1,0 +1,51 @@
+package com.dadok.gaerval.global.config.externalapi;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.dadok.gaerval.domain.book.dto.request.SearchTarget;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+
+@Component
+@RequiredArgsConstructor
+public class WebClientBookApiOperations implements ExternalBookApiOperations{
+
+	private final WebClient webClient;
+
+	@Override
+	public Flux<String> searchBooks(String query, int page, int size, String sort) {
+		return webClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.queryParam("query", query)
+				.queryParam("page", page)
+				.queryParam("size", size)
+				.queryParam("sort", sort)
+				.build())
+			.acceptCharset(StandardCharsets.UTF_8)
+			.accept(MediaType.APPLICATION_JSON)
+			.retrieve()
+			.bodyToFlux(String.class);
+	}
+
+	@Override
+	public Flux<String> searchBooksWithTargetRestriction(String query, SearchTarget searchTarget, int page, int size,
+		String sort) {
+		return webClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.queryParam("query", query)
+				.queryParam("target", searchTarget.getName())
+				.queryParam("page", page)
+				.queryParam("size", size)
+				.queryParam("sort", sort)
+				.build())
+			.acceptCharset(StandardCharsets.UTF_8)
+			.accept(MediaType.APPLICATION_JSON)
+			.retrieve()
+			.bodyToFlux(String.class);
+	}
+}

--- a/src/main/java/com/dadok/gaerval/global/config/externalapi/WebClientConfig.java
+++ b/src/main/java/com/dadok/gaerval/global/config/externalapi/WebClientConfig.java
@@ -1,4 +1,4 @@
-package com.dadok.gaerval.global.config.webclient;
+package com.dadok.gaerval.global.config.externalapi;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/dadok/gaerval/global/config/externalapi/WebClientProperties.java
+++ b/src/main/java/com/dadok/gaerval/global/config/externalapi/WebClientProperties.java
@@ -1,4 +1,4 @@
-package com.dadok.gaerval.global.config.webclient;
+package com.dadok.gaerval.global.config.externalapi;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;

--- a/src/main/java/com/dadok/gaerval/global/util/CommonValidator.java
+++ b/src/main/java/com/dadok/gaerval/global/util/CommonValidator.java
@@ -65,7 +65,7 @@ public class CommonValidator {
 	public static void validateLengthInRange(String value, int minLength, int maxLength, String valueName) {
 		validateNotnull(value, valueName);
 
-		if (value.length() >= maxLength || value.length() <= minLength) {
+		if (value.length() >= maxLength || value.length() < minLength) {
 			log.info("에러 발생. valueName : {}, value : {}, length : {}",
 				valueName, value, value.length());
 			log.debug("에러 발생. valueName : {}, value : {}, length : {}",

--- a/src/test/java/com/dadok/gaerval/domain/book/entity/BookTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/entity/BookTest.java
@@ -1,12 +1,12 @@
 package com.dadok.gaerval.domain.book.entity;
 
-
-import com.dadok.gaerval.global.error.exception.InvalidArgumentException;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.dadok.gaerval.global.config.security.AuthProvider;
+import com.dadok.gaerval.global.error.exception.InvalidArgumentException;
 import com.dadok.gaerval.testutil.BookObjectProvider;
 
 
@@ -94,5 +94,93 @@ class BookTest {
 		book.changeDeleted(true);
 		// Then
 		assertTrue(book.isDeleted());
+	}
+
+	@Test
+	@DisplayName("도서 제목이 변경된다.")
+	void change_book_title() {
+		// Given
+		Book book = BookObjectProvider.createRequiredFieldBook();
+		String newTitle = "새로운 도서 제목";
+		// When
+		book.changeTitle(newTitle);
+		// Then
+		assertEquals(newTitle, book.getTitle());
+	}
+
+
+	@Test
+	@DisplayName("도서 저자가 변경된다.")
+	void change_book_author() {
+		// Given
+		Book book = BookObjectProvider.createRequiredFieldBook();
+		String newAuthor = "새로운 도서 저자";
+		// When
+		book.changeAuthor(newAuthor);
+		// Then
+		assertEquals(newAuthor, book.getAuthor());
+	}
+
+
+
+	@Test
+	@DisplayName("도서 소개가 변경된다.")
+	void change_book_contents() {
+		// Given
+		Book book = BookObjectProvider.createRequiredFieldBook();
+		String newContents = "새로운 도서 소개";
+		// When
+		book.changeContents(newContents);
+		// Then
+		assertEquals(newContents, book.getContents());
+	}
+
+	@Test
+	@DisplayName("도서 URL이 변경된다.")
+	void change_book_url() {
+		// Given
+		Book book = BookObjectProvider.createRequiredFieldBook();
+		String newUrl = BookObjectProvider.url;
+		// When
+		book.changeUrl(newUrl);
+		// Then
+		assertEquals(newUrl, book.getUrl());
+	}
+
+	@Test
+	@DisplayName("도서 이미지 URL이 변경된다.")
+	void change_book_imageUrl() {
+		// Given
+		Book book = BookObjectProvider.createRequiredFieldBook();
+		String newImageUrl = BookObjectProvider.imageKey	;
+		// When
+		book.changeImageUrl(newImageUrl);
+		// Then
+		assertEquals(newImageUrl, book.getImageUrl());
+	}
+
+
+	@Test
+	@DisplayName("도서 이미지 키가 변경된다.")
+	void change_book_imageKey() {
+		// Given
+		Book book = BookObjectProvider.createRequiredFieldBook();
+		String newImageKey = BookObjectProvider.imageKey;
+		// When
+		book.changeImageKey(newImageKey);
+		// Then
+		assertEquals(newImageKey, book.getImageKey());
+	}
+
+	@Test
+	@DisplayName("api provider가 변경된다.")
+	void change_api_provider() {
+		// given
+		Book book = BookObjectProvider.createRequiredFieldBook();
+		String apiProvider = AuthProvider.NAVER.getName();
+		// when
+		book.changeApiProvider(apiProvider);
+		// then
+		assertEquals(apiProvider, book.getApiProvider());
 	}
 }

--- a/src/test/java/com/dadok/gaerval/domain/book/service/BookDataProcessorTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/service/BookDataProcessorTest.java
@@ -1,0 +1,53 @@
+package com.dadok.gaerval.domain.book.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.dadok.gaerval.domain.book.entity.Book;
+import com.dadok.gaerval.testutil.BookObjectProvider;
+
+class BookDataProcessorTest {
+
+	@DisplayName("일반적이지 않은 데이터의 전처리에 성공한다.")
+	@ParameterizedTest
+	@MethodSource("provideStringsForContents")
+	 void processInvalid_success(String contents) {
+		// given
+		String title = "";
+		List<String> authors = new ArrayList<>();
+		String isbn = "1234567891";
+		String publisher = "";
+		String url = BookObjectProvider.url;
+		String imageUrl = BookObjectProvider.imageUrl;
+
+		// when
+		Book weirdBook = BookDataProcessor.process(title, authors, contents,isbn, url, imageUrl, publisher);
+
+		// then
+		assertEquals("책 제목 미상", weirdBook.getTitle());
+		assertEquals("저자 미상", weirdBook.getAuthor());
+		assertTrue(weirdBook.getContents().length() < 2000);
+		assertEquals("출판사 미상", weirdBook.getPublisher());
+	}
+
+
+	private static Stream<Arguments> provideStringsForContents() {
+		return Stream.of(
+			Arguments.of(null, true),
+			Arguments.of("", true),
+			Arguments.of("  ", true),
+			Arguments.of(StringUtils.repeat("a", 1999), false)
+		);
+	}
+
+}


### PR DESCRIPTION
### 🍀 목적
- open api 호출 작업 추상화하고, 수신데이터를 전처리해 에러를 방지하기 위함

### 🌹 추가사항<!-- 있다면 적고 없다면 적지 않는다.-->
- `ExternalBookApiOperations` 인터페이스와 `WebClientBookApiOperations` 구체추가
- `BookDataProcessor`로 데이터 전처리

### ☕ 변경사항<!-- 있다면 적고 없다면 적지 않는다.-->
- DefaultBookService에서 WebClient 직접참조하지 않고 `WebClientBookApiOperations`에서 처리


### ❓ pr 포인트
- 책 저자, 출판사, 책 소개 데이터가 내려오지 않는 경우가 있어서 전처리 진행했습니다.
- 추상화가 적절하게 이루어졌는지 검토부탁드려요~

### 📢 Help


resolves #60 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
