### PR TITLE
config : logback 설정 추가

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,10 +7,10 @@
         <property name="PATH" value="./logs/local.log"/>
     </springProfile>
 
-<!--    &lt;!&ndash; profile이 aws인 경우&ndash;&gt;-->
-<!--    <springProfile name="aws">-->
-<!--        <property name="PATH" value="/var/logs/dev.log"/>-->
-<!--    </springProfile>-->
+    <!-- profile이 develop인 경우-->
+    <springProfile name="develop">
+        <property name="PATH" value="/home/ec2-user/logs/develop.log"/>
+    </springProfile>
 
     <!-- 스프링부트 기본 로깅 패턴 -->
     <conversionRule conversionWord="clr"

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="LOG_LEVEL" source="logging.level.com.dadok.gaerval"/>
+
+    <!-- profile이 local인 경우-->
+    <springProfile name="local">
+        <property name="PATH" value="./logs/local.log"/>
+    </springProfile>
+
+<!--    &lt;!&ndash; profile이 aws인 경우&ndash;&gt;-->
+<!--    <springProfile name="aws">-->
+<!--        <property name="PATH" value="/var/logs/dev.log"/>-->
+<!--    </springProfile>-->
+
+    <!-- 스프링부트 기본 로깅 패턴 -->
+    <conversionRule conversionWord="clr"
+                    converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+    <conversionRule conversionWord="wex"
+                    converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+
+    <conversionRule conversionWord="wEx"
+                    converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+
+    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
+
+    <!-- 파일로그 패턴 -->
+    <property name="LOG_PATTERN" value="%-5level %d{yy-MM-dd HH:mm:ss}[%thread] [%logger{0}:%line] - %msg%n"/>
+
+    <!-- 콘솔 로그는 스프링부트 기본 패턴 적용 -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 파일 경로 및 이름 -->
+        <file>${PATH}</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <!-- 로그파일을 교체하는 정책 TimeBasedRollingPolicy: 시간 단위 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./logs/dadok-file.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>30MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <!--전체 용량 제어(maxHistory와 함께 사용 필수)-->
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
<!--제목은 `[#이슈번호] 이슈 제목` 으로 작성한다.-->

[로깅 조사 문서](https://www.notion.so/backend-devcourse/a7f17498e48342a19d88c85ed797f9a8)

### 🍀 목적
- 파일 로깅용 `logback.xml`추가

### 🌹 추가사항<!-- 있다면 적고 없다면 적지 않는다.-->
- 콘솔 로깅은 현재 스프링부트 로깅 포맷패턴과 동일하게 적용했습니다.

### ❓ pr 포인트
- 로깅 전략 : 파일 로깅은 각 파일 크기 30MB, 보관기관 30일, 전체로그파일 용량 : 3GB

### 📢 Help
- 개발서버 로그 저장 경로를 `/var/log`로 하면 될지, active profile은 뭘로 하면 될지 확인이 필요합니다.
- 코멘트 하기 편하게 일단 PR로 올립니다~

resolves #이슈번호<!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
