### PR TITLE
미사용자를 위한 책장 추천리스트 조회 api 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -199,6 +199,7 @@ include::{snippets}/bookshelf-controller-slice-test/find-book-shelf-with-user-jo
 include::{snippets}/bookshelf-controller-slice-test/find-book-shelf-with-user-job/http-response.adoc[]
 
 ==== Response fields
+
 include::{snippets}/bookshelf-controller-slice-test/find-book-shelf-with-user-job/response-fields.adoc[]
 
 === 책장 책 조회
@@ -224,9 +225,28 @@ include::{snippets}/bookshelf-controller-slice-test/find-books-in-book-shelf/req
 include::{snippets}/bookshelf-controller-slice-test/find-books-in-book-shelf/http-response.adoc[]
 
 ==== Response fields
+
 include::{snippets}/bookshelf-controller-slice-test/find-books-in-book-shelf/response-fields.adoc[]
 
 '''
+
+=== 전체 책장 요약 리스트 (미로그인 사용자용 추천)
+
+==== Request
+
+include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves/http-request.adoc[]
+
+==== Request Header
+
+include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves/http-response.adoc[]
+
+==== Response fields
+
+include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves/response-fields.adoc[]
 
 === 직군별 책장 요약 리스트 (추천)
 
@@ -418,7 +438,6 @@ include::{snippets}/book-group-controller-slice-test/create-book-group/http-resp
 
 include::{snippets}/book-group-controller-slice-test/create-book-group/response-headers.adoc[]
 
-
 === 모임 상세 조회
 
 ==== Request
@@ -428,7 +447,6 @@ include::{snippets}/book-group-controller-slice-test/find-group_success/http-req
 ==== Request Header
 
 include::{snippets}/book-group-controller-slice-test/find-group_success/request-headers.adoc[]
-
 
 ==== Path Parameter
 
@@ -441,7 +459,6 @@ include::{snippets}/book-group-controller-slice-test/find-group_success/http-res
 ==== Response fields
 
 include::{snippets}/book-group-controller-slice-test/find-group_success/response-fields.adoc[]
-
 
 === 모임 전체 조회
 
@@ -486,8 +503,6 @@ include::{snippets}/book-group-controller-slice-test/find-my-book-groups/http-re
 ==== Response fields
 
 include::{snippets}/book-group-controller-slice-test/find-my-book-groups/response-fields.adoc[]
-
-
 
 == Job - 직군, 직업
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -230,7 +230,7 @@ include::{snippets}/bookshelf-controller-slice-test/find-books-in-book-shelf/res
 
 '''
 
-=== 전체 책장 요약 리스트 (미로그인 사용자용 추천)
+=== 전체 직군 책장 요약 리스트 (미로그인 사용자용 추천)
 
 ==== Request
 
@@ -248,27 +248,27 @@ include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves/
 
 include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves/response-fields.adoc[]
 
-=== 직군별 책장 요약 리스트 (추천)
+=== 직군별 책장 요약 리스트 (로그인 사용자 추천)
 
 ==== Request
 
-include::{snippets}/bookshelf-controller-slice-test/find-bookshelves-by-job-group/http-request.adoc[]
+include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves-by-job-group/http-request.adoc[]
 
 ==== Request Param
 
-include::{snippets}/bookshelf-controller-slice-test/find-bookshelves-by-job-group/request-parameters.adoc[]
+include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves-by-job-group/request-parameters.adoc[]
 
 ==== Request Header
 
-include::{snippets}/bookshelf-controller-slice-test/find-bookshelves-by-job-group/request-headers.adoc[]
+include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves-by-job-group/request-headers.adoc[]
 
 ==== Response
 
-include::{snippets}/bookshelf-controller-slice-test/find-bookshelves-by-job-group/http-response.adoc[]
+include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves-by-job-group/http-response.adoc[]
 
 ==== Response fields
 
-include::{snippets}/bookshelf-controller-slice-test/find-bookshelves-by-job-group/response-fields.adoc[]
+include::{snippets}/bookshelf-controller-slice-test/find-suggestion-bookshelves-by-job-group/response-fields.adoc[]
 
 === 책장 책 넣기
 

--- a/src/main/java/com/dadok/gaerval/domain/book/dto/response/BookResponse.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/dto/response/BookResponse.java
@@ -1,5 +1,5 @@
 package com.dadok.gaerval.domain.book.dto.response;
 
 public record BookResponse(String title, String author, String isbn, String contents, String url,
-						   String imageUrl, String apiProvider, String publisher, String imageKey, Long id) {
+						   String imageUrl, String apiProvider, String publisher, String imageKey, Long bookId) {
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfController.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfController.java
@@ -3,6 +3,7 @@ package com.dadok.gaerval.domain.bookshelf.api;
 import static org.springframework.http.MediaType.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,7 @@ import com.dadok.gaerval.domain.bookshelf.dto.response.BookInShelfResponses;
 import com.dadok.gaerval.domain.bookshelf.dto.response.BookShelfDetailResponse;
 import com.dadok.gaerval.domain.bookshelf.dto.response.BookShelfSummaryResponse;
 import com.dadok.gaerval.domain.bookshelf.dto.response.SuggestionBookshelvesByJobGroupResponses;
+import com.dadok.gaerval.domain.bookshelf.dto.response.SuggestionBookshelvesResponses;
 import com.dadok.gaerval.domain.bookshelf.service.BookshelfService;
 import com.dadok.gaerval.global.config.security.UserPrincipal;
 
@@ -35,6 +37,16 @@ import lombok.RequiredArgsConstructor;
 public class BookshelfController {
 
 	private final BookshelfService bookshelfService;
+
+	@GetMapping(value = "/suggestions/bookshelves/default",
+		consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+	@PreAuthorize(value = "hasAnyRole('ROLE_ANONYMOUS','ROLE_ADMIN', 'ROLE_USER')")
+	public ResponseEntity<SuggestionBookshelvesResponses> findSuggestionBookshelves(
+	) {
+		SuggestionBookshelvesResponses responses =
+			bookshelfService.findSuggestionBookshelves();
+		return ResponseEntity.ok().body(responses);
+	}
 
 	/**
 	 * <pre>
@@ -48,7 +60,7 @@ public class BookshelfController {
 		consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
 	public ResponseEntity<SuggestionBookshelvesByJobGroupResponses> findSuggestionBookshelvesByJobGroup(
-		@RequestParam(name = "job_group") String jobGroup,
+		@RequestParam(name = "job_group") @NotBlank String jobGroup,
 		@AuthenticationPrincipal UserPrincipal userPrincipal
 	) {
 		Long userId = userPrincipal.getUserId();

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfController.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfController.java
@@ -38,6 +38,13 @@ public class BookshelfController {
 
 	private final BookshelfService bookshelfService;
 
+	/**
+	 * <Pre>
+	 * 미로그인 사용자 접근용 인기 책장을 조회한다.
+	 * </Pre>
+	 *
+	 * @return status : ok , SuggestionBookshelvesResponses : 책장 5개와 책장의 일부 책 list
+	 */
 	@GetMapping(value = "/suggestions/bookshelves/default",
 		consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ANONYMOUS','ROLE_ADMIN', 'ROLE_USER')")
@@ -54,7 +61,7 @@ public class BookshelfController {
 	 * </pre>
 	 *
 	 * @param jobGroup
-	 * @return status : ok , SuggestionBookshelvesByJobGroupResponses : 책장과 책장의 일부 책 list
+	 * @return status : ok , SuggestionBookshelvesByJobGroupResponses : 책장 5개와 책장의 일부 책 list
 	 */
 	@GetMapping(value = "/suggestions/bookshelves",
 		consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/dto/response/SuggestionBookshelvesResponses.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/dto/response/SuggestionBookshelvesResponses.java
@@ -1,0 +1,8 @@
+package com.dadok.gaerval.domain.bookshelf.dto.response;
+
+import java.util.List;
+
+public record SuggestionBookshelvesResponses(
+	List<BookShelfSummaryResponse> bookshelfResponses
+) {
+}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfSupport.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfSupport.java
@@ -15,4 +15,5 @@ public interface BookshelfSupport {
 
 	List<BookShelfSummaryResponse> findSuggestionsByJobGroup(JobGroup jobGroup, Long userId, int limit);
 
+	List<BookShelfSummaryResponse> findAllSuggestions(int limit);
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfSupportImpl.java
@@ -91,4 +91,21 @@ public class BookshelfSupportImpl implements BookshelfSupport {
 							book.id, book.title, book.imageUrl)
 					))));
 	}
+
+	@Override
+	public List<BookShelfSummaryResponse> findAllSuggestions(int limit) {
+		return query.from(bookshelf)
+			.leftJoin(bookshelf.bookshelfItems, bookshelfItem)
+			.leftJoin(bookshelfItem.book, book)
+			.orderBy(bookshelf.bookshelfItems.size().desc()) //TODO 인기척도 후에 수정 필요
+			.limit(limit)
+			.transform(
+				groupBy(bookshelf.id).list(constructor(BookShelfSummaryResponse.class,
+					bookshelf.id,
+					bookshelf.name,
+					list(
+						constructor(BookShelfSummaryResponse.BookSummaryResponse.class,
+							book.id, book.title, book.imageUrl)
+					))));
+	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/service/BookshelfService.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/service/BookshelfService.java
@@ -9,6 +9,7 @@ import com.dadok.gaerval.domain.bookshelf.dto.response.BookShelfDetailResponse;
 import com.dadok.gaerval.domain.bookshelf.dto.response.BookShelfSummaryResponse;
 import com.dadok.gaerval.domain.bookshelf.dto.response.DetailBookshelfResponse;
 import com.dadok.gaerval.domain.bookshelf.dto.response.SuggestionBookshelvesByJobGroupResponses;
+import com.dadok.gaerval.domain.bookshelf.dto.response.SuggestionBookshelvesResponses;
 import com.dadok.gaerval.domain.bookshelf.entity.Bookshelf;
 import com.dadok.gaerval.domain.user.entity.User;
 
@@ -36,4 +37,5 @@ public interface BookshelfService {
 
 	void updateJobIdByUserId(Long userId, Long jobId);
 
+	SuggestionBookshelvesResponses findSuggestionBookshelves();
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfService.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfService.java
@@ -16,6 +16,7 @@ import com.dadok.gaerval.domain.bookshelf.dto.response.BookShelfDetailResponse;
 import com.dadok.gaerval.domain.bookshelf.dto.response.BookShelfSummaryResponse;
 import com.dadok.gaerval.domain.bookshelf.dto.response.DetailBookshelfResponse;
 import com.dadok.gaerval.domain.bookshelf.dto.response.SuggestionBookshelvesByJobGroupResponses;
+import com.dadok.gaerval.domain.bookshelf.dto.response.SuggestionBookshelvesResponses;
 import com.dadok.gaerval.domain.bookshelf.entity.Bookshelf;
 import com.dadok.gaerval.domain.bookshelf.entity.BookshelfItem;
 import com.dadok.gaerval.domain.bookshelf.repository.BookshelfItemRepository;
@@ -138,6 +139,11 @@ public class DefaultBookshelfService implements BookshelfService {
 		Bookshelf bookshelf = bookshelfRepository.findByUserId(userId)
 			.orElseThrow(() -> new ResourceNotfoundException(Bookshelf.class));
 		bookshelf.changeJobId(jobId);
+	}
+
+	@Override
+	public SuggestionBookshelvesResponses findSuggestionBookshelves() {
+		return new SuggestionBookshelvesResponses(bookshelfRepository.findAllSuggestions(5));
 	}
 
 	private Bookshelf validationBookshelfUser(Long userId, Long bookshelfId) {

--- a/src/test/java/com/dadok/gaerval/domain/book/api/BookControllerSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/api/BookControllerSliceTest.java
@@ -152,7 +152,7 @@ class BookControllerSliceTest extends ControllerTest {
 					fieldWithPath("imageKey").type(JsonFieldType.STRING)
 						.optional()
 						.description("이미지키"),
-					fieldWithPath("id").type(JsonFieldType.NUMBER)
+					fieldWithPath("bookId").type(JsonFieldType.NUMBER)
 						.optional()
 						.description("도서 id")
 				)

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfRepositoryTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfRepositoryTest.java
@@ -54,9 +54,15 @@ class BookshelfRepositoryTest {
 		assertThat(res.isEmpty()).isTrue();
 	}
 
-	@DisplayName("인기 책장 요약 list 조회 - findSuggestionsByJobGroup 쿼리테스트")
+	@DisplayName("직군별 인기 책장 요약 list 조회 - findSuggestionsByJobGroup 쿼리테스트")
 	@Test
 	void findSuggestionsByJobGroup() {
 		bookshelfRepository.findSuggestionsByJobGroup(JobGroup.DEVELOPMENT, 10L, 1);
+	}
+
+	@DisplayName("인기 책장 요약 list 조회 - findAllSuggestions 쿼리테스트")
+	@Test
+	void findAllSuggestions() {
+		bookshelfRepository.findAllSuggestions(1);
 	}
 }

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfServiceSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfServiceSliceTest.java
@@ -320,6 +320,30 @@ class DefaultBookshelfServiceSliceTest {
 
 	}
 
+	@DisplayName("findSuggestionBookshelves - 인기 책장 리스트 조회 - 성공")
+	@Test
+	void findSuggestionBookshelves_success() {
+		// Given
+		String jobGroup = JobGroup.HR.getDescription();
+
+		var expectResponses = List.of(new BookShelfSummaryResponse(23L, "영지님의 책장",
+			List.of(new BookShelfSummaryResponse.BookSummaryResponse(1L, "해리포터",
+				"https://www.producttalk.org/wp-content/uploads/2018/06/www.maxpixel.net-Ears-Zoo-Hippopotamus-Eye-Animal-World-Hippo-2878867.jpg"))
+		));
+
+		given(bookshelfRepository.findAllSuggestions(5))
+			.willReturn(expectResponses);
+
+		// When
+		var responses = bookshelfService.findSuggestionBookshelves();
+
+		// Then
+		verify(bookshelfRepository).findAllSuggestions(5);
+
+		assertThat(responses.bookshelfResponses()).hasSize(1);
+		assertThat(responses.bookshelfResponses().get(0).books()).hasSize(1);
+	}
+
 	@DisplayName("findSuggestionBookshelvesByJobGroup- 존재하지 않은 직업군의 책장 리스트 조회 - 실패")
 	@ParameterizedTest
 	@ValueSource(strings = {"개 발 ", "백수", "노 직군", "영지", "다독"})
@@ -500,7 +524,5 @@ class DefaultBookshelfServiceSliceTest {
 		assertThat(bookShelf).hasFieldOrPropertyWithValue("jobId", idToUpdate);
 		verify(bookshelfRepository).findByUserId(userId);
 	}
-
-
 
 }


### PR DESCRIPTION
<!--제목은 `[#이슈번호] 이슈 제목` 으로 작성한다.-->

### 🍀 목적
미사용자를 위한 책장 추천리스트 조회 api 구현
- 미사용자를 위한 api여서 로그인 유저가 접근시 자신의 책장이 포함되어 있을 수 있습니다~!