### PR TITLE
fix : 모임 댓글 수정, 삭제 버그 수정

### DIFF
--- a/src/main/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentController.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentController.java
@@ -90,18 +90,19 @@ public class BookGroupCommentController {
 	 * @return status : ok, BookGroupCommentResponse : 수정된 댓글 정보
 	 */
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
-	@PatchMapping(value = "/{groupId}/comment", consumes = APPLICATION_JSON_VALUE)
+	@PatchMapping(value = "/{groupId}/comments/{commentId}", consumes = APPLICATION_JSON_VALUE)
 	public ResponseEntity<BookGroupCommentResponse> updateBookGroupComment(
 		@PathVariable Long groupId,
+		@PathVariable Long commentId,
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@RequestBody @Valid BookGroupCommentUpdateRequest bookGroupCommentUpdateRequest
 	) {
-		BookGroupCommentResponse bookGroupComment = bookGroupCommentService.updateBookGroupComment(groupId, userPrincipal.getUserId(),
+		bookGroupCommentService.updateBookGroupComment(groupId, userPrincipal.getUserId(),
+			commentId,
 			bookGroupCommentUpdateRequest);
 
-		return ResponseEntity.ok().body(bookGroupComment);
+		return ResponseEntity.ok().build();
 	}
-
 
 	/**
 	 * <Pre>
@@ -113,7 +114,7 @@ public class BookGroupCommentController {
 	 * @return status : ok
 	 */
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
-	@DeleteMapping(value = "/{groupId}/comment", consumes = APPLICATION_JSON_VALUE)
+	@DeleteMapping(value = "/{groupId}/comments", consumes = APPLICATION_JSON_VALUE)
 	public ResponseEntity<Void> updateBookGroupComment(
 		@PathVariable Long groupId,
 		@AuthenticationPrincipal UserPrincipal userPrincipal,

--- a/src/main/java/com/dadok/gaerval/domain/book_group/dto/request/BookGroupCommentUpdateRequest.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/dto/request/BookGroupCommentUpdateRequest.java
@@ -1,12 +1,9 @@
 package com.dadok.gaerval.domain.book_group.dto.request;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 public record BookGroupCommentUpdateRequest(
-	@NotNull(message = "수정시에는 commendId를 반드시 입력해야합니다.")
-	Long commentId,
 
 	@NotBlank(message = "comment는 빈 값일 수 없습니다.")
 	@Size(max = 2000)

--- a/src/main/java/com/dadok/gaerval/domain/book_group/entity/GroupComment.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/entity/GroupComment.java
@@ -18,6 +18,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import com.dadok.gaerval.domain.book_group.exception.InvalidCommentException;
+import com.dadok.gaerval.domain.book_group.exception.NotMatchedCommentAuthorException;
 import com.dadok.gaerval.domain.user.entity.User;
 import com.dadok.gaerval.global.common.entity.BaseTimeColumn;
 import com.dadok.gaerval.global.error.ErrorCode;
@@ -110,8 +111,11 @@ public class GroupComment extends BaseTimeColumn {
 		return this.parentComment != null;
 	}
 
-	public void changeContents(String contents) {
+	public void changeContents(Long requestUserId, String contents) {
 		validateLengthLessThen(contents, 2000, "contents");
+		if (!Objects.equals(this.user.getId(), requestUserId)) {
+			throw new NotMatchedCommentAuthorException();
+		}
 		this.contents = contents;
 	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/book_group/exception/NotMatchedCommentAuthorException.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/exception/NotMatchedCommentAuthorException.java
@@ -1,0 +1,26 @@
+package com.dadok.gaerval.domain.book_group.exception;
+
+import static com.dadok.gaerval.global.error.ErrorCode.*;
+
+import com.dadok.gaerval.global.error.ErrorCode;
+import com.dadok.gaerval.global.error.exception.BusinessException;
+
+public class NotMatchedCommentAuthorException extends BusinessException {
+
+	private final ErrorCode errorCode = NOT_MATCHED_COMMENT_AUTHOR;
+
+	public NotMatchedCommentAuthorException() {
+		super(NOT_MATCHED_COMMENT_AUTHOR);
+	}
+
+	@Override
+	public ErrorCode getErrorCode() {
+		return this.errorCode;
+	}
+
+	@Override
+	public String getMessage() {
+		return this.errorCode.getMessage();
+	}
+
+}

--- a/src/main/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentService.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentService.java
@@ -3,10 +3,9 @@ package com.dadok.gaerval.domain.book_group.service;
 import java.util.Optional;
 
 import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentCreateRequest;
- import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentDeleteRequest;
+import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentDeleteRequest;
 import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentSearchRequest;
 import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentUpdateRequest;
-import com.dadok.gaerval.domain.book_group.dto.response.BookGroupCommentResponse;
 import com.dadok.gaerval.domain.book_group.dto.response.BookGroupCommentResponses;
 import com.dadok.gaerval.domain.book_group.entity.GroupComment;
 
@@ -16,7 +15,9 @@ public interface BookGroupCommentService {
 
 	Long createBookGroupComment(Long bookGroupId, Long userId, BookGroupCommentCreateRequest request);
 
-	BookGroupCommentResponse updateBookGroupComment(Long bookGroupId, Long userId, BookGroupCommentUpdateRequest bookGroupCommentUpdateRequest);
+	void updateBookGroupComment(Long bookGroupId, Long userId, Long commentId,
+		BookGroupCommentUpdateRequest bookGroupCommentUpdateRequest);
+
 	GroupComment getById(Long id);
 
 	Optional<GroupComment> findById(Long id);

--- a/src/main/java/com/dadok/gaerval/domain/book_group/service/DefaultBookGroupCommentService.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/service/DefaultBookGroupCommentService.java
@@ -9,7 +9,6 @@ import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentCreateReq
 import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentDeleteRequest;
 import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentSearchRequest;
 import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentUpdateRequest;
-import com.dadok.gaerval.domain.book_group.dto.response.BookGroupCommentResponse;
 import com.dadok.gaerval.domain.book_group.dto.response.BookGroupCommentResponses;
 import com.dadok.gaerval.domain.book_group.entity.BookGroup;
 import com.dadok.gaerval.domain.book_group.entity.GroupComment;
@@ -80,15 +79,16 @@ public class DefaultBookGroupCommentService implements BookGroupCommentService {
 		return bookGroupCommentRepository.findById(id);
 	}
 
+	@Transactional
 	@Override
-	public BookGroupCommentResponse updateBookGroupComment(Long bookGroupId, Long userId,
-		BookGroupCommentUpdateRequest bookGroupCommentUpdateRequest) {
-		GroupComment groupComment = this.getById(bookGroupCommentUpdateRequest.commentId());
-		groupComment.changeContents(bookGroupCommentUpdateRequest.comment());
-		checkGroupMember(userId, bookGroupId);
-		return bookGroupCommentRepository.findGroupComment(bookGroupCommentUpdateRequest.commentId(), userId, bookGroupId);
+	public void updateBookGroupComment(Long bookGroupId, Long requestUserId,
+		Long commentId, BookGroupCommentUpdateRequest bookGroupCommentUpdateRequest) {
+
+		GroupComment groupComment = this.getById(commentId);
+		groupComment.changeContents(requestUserId, bookGroupCommentUpdateRequest.comment());
 	}
 
+	@Transactional
 	@Override
 	public void deleteBookGroupComment(Long bookGroupId, Long userId,
 		BookGroupCommentDeleteRequest bookGroupCommentDeleteRequest) {

--- a/src/main/java/com/dadok/gaerval/global/error/ErrorCode.java
+++ b/src/main/java/com/dadok/gaerval/global/error/ErrorCode.java
@@ -42,7 +42,10 @@ public enum ErrorCode {
 	EXPIRED_JOIN_GROUP(HttpStatus.BAD_REQUEST, "BG5", "모임 가입 기간이 지났습니다."),
 	CANNOT_DELETE_MEMBER_EXIST(HttpStatus.BAD_REQUEST, "BG6", "멤버가 존재하는 모임은 삭제할 수 없습니다."),
 	LESS_THAN_CURRENT_MEMBERS(HttpStatus.BAD_REQUEST, "BG7", "모임 최대 인원은 현재 참여 인원(%s 명)보다 작을 수 없습니다"),
-	NOT_CONTAIN_BOOK_GROUP_MEMBER(HttpStatus.UNAUTHORIZED, "BG8", "모임에 참여하지않은 사용자 입니다.");
+	NOT_CONTAIN_BOOK_GROUP_MEMBER(HttpStatus.UNAUTHORIZED, "BG8", "모임에 참여하지않은 사용자 입니다."),
+	NOT_MATCHED_COMMENT_AUTHOR(HttpStatus.FORBIDDEN, "BGC9", "요청자가 작성한 코멘트가 아닙니다.")
+
+	;
 
 	private final HttpStatus status;
 

--- a/src/main/resources/sql/clean_up.sql
+++ b/src/main/resources/sql/clean_up.sql
@@ -1,27 +1,39 @@
 SET FOREIGN_KEY_CHECKS = 0;
 
 truncate table book_comments;
+alter table book_comments auto_increment = 1;
 
 truncate table bookshelf_item;
+alter table bookshelf_item auto_increment = 1;
 
 truncate table bookshelves;
+alter table bookshelves auto_increment = 1;
 
 truncate table group_comments;
+alter table group_comments auto_increment = 1;
 
 truncate table group_member;
+alter table group_member auto_increment = 1;
 
 truncate table book_groups;
+alter table book_groups auto_increment = 1;
 
 truncate table books;
+alter table books auto_increment = 1;
 
 truncate table oauth2_authorized_client;
+alter table oauth2_authorized_client auto_increment = 1;
 
 truncate table user_authorities;
+alter table user_authorities auto_increment = 1;
 
 truncate table authorities;
+alter table authorities auto_increment = 1;
 
 truncate table users;
+alter table users auto_increment = 1;
 
 truncate table jobs;
+alter table jobs auto_increment = 1;
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentControllerSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentControllerSliceTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +34,6 @@ import com.dadok.gaerval.domain.book_group.service.BookGroupCommentService;
 import com.dadok.gaerval.global.util.QueryDslUtil;
 import com.dadok.gaerval.global.util.SortDirection;
 import com.dadok.gaerval.testutil.BookGroupCommentObjectProvider;
-import com.dadok.gaerval.testutil.UserObjectProvider;
 import com.dadok.gaerval.testutil.WithMockCustomOAuth2LoginUser;
 
 @WebMvcTest(controllers = BookGroupCommentController.class)
@@ -166,18 +164,14 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 		Long groupId = 234L;
 		Long bookGroupCommentId = 234L;
 		String modifiedComment = "이 책 싫어요";
-		BookGroupCommentUpdateRequest request = new BookGroupCommentUpdateRequest(123L,
-			modifiedComment);
+		BookGroupCommentUpdateRequest request = new BookGroupCommentUpdateRequest(modifiedComment);
 
-		BookGroupCommentResponse bookGroupCommentResponse = new BookGroupCommentResponse(bookGroupCommentId,
-			modifiedComment, groupId, null, 1L, UserObjectProvider.PICTURE_URL, LocalDateTime.of(2023, 3, 7, 12, 11)
-			, LocalDateTime.now(), "티나", true);
+		willDoNothing().given(bookGroupCommentService)
+			.updateBookGroupComment(groupId, 1L, bookGroupCommentId, request);
 
-		given(bookGroupCommentService.updateBookGroupComment(groupId, 1L, request))
-			.willReturn(bookGroupCommentResponse);
 
 		// when then
-		mockMvc.perform(patch("/api/book-groups/{groupId}/comment", groupId)
+		mockMvc.perform(patch("/api/book-groups/{groupId}/comments/{commentId}", groupId, bookGroupCommentId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.header(ACCESS_TOKEN_HEADER_NAME, MOCK_ACCESS_TOKEN)
 				.characterEncoding(StandardCharsets.UTF_8)
@@ -191,22 +185,16 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 					headerWithName(HttpHeaders.CONTENT_TYPE).description(CONTENT_TYPE_JSON_DESCRIPTION)
 				),
 				pathParameters(
-					parameterWithName("groupId").description("모임 ID")
+					parameterWithName("groupId").description("모임 Id"),
+					parameterWithName("commentId").description("모임 댓글 Id")
 				),
 				requestFields(
-					fieldWithPath("commentId").type(JsonFieldType.NUMBER)
-						.description("수정할 댓글 아이디")
-						.attributes(
-							constrainsAttribute(BookGroupCommentUpdateRequest.class, "commentId")
-						)
-					,
 					fieldWithPath("comment").type(JsonFieldType.STRING).description("수정할 댓글 내용")
 						.attributes(
 							constrainsAttribute(BookGroupCommentUpdateRequest.class, "comment")
 						)
 				)
 			));
-
 
 	}
 
@@ -224,7 +212,7 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 
 
 		// when then
-		mockMvc.perform(delete("/api/book-groups/{groupId}/comment", groupId)
+		mockMvc.perform(delete("/api/book-groups/{groupId}/comments", groupId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.header(ACCESS_TOKEN_HEADER_NAME, MOCK_ACCESS_TOKEN)
 				.characterEncoding(StandardCharsets.UTF_8)

--- a/src/test/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentServiceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentServiceTest.java
@@ -1,0 +1,103 @@
+package com.dadok.gaerval.domain.book_group.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import com.dadok.gaerval.domain.book.entity.Book;
+import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentUpdateRequest;
+import com.dadok.gaerval.domain.book_group.entity.BookGroup;
+import com.dadok.gaerval.domain.book_group.entity.GroupComment;
+import com.dadok.gaerval.domain.book_group.exception.NotMatchedCommentAuthorException;
+import com.dadok.gaerval.domain.user.entity.Authority;
+import com.dadok.gaerval.domain.user.entity.Role;
+import com.dadok.gaerval.domain.user.entity.User;
+import com.dadok.gaerval.domain.user.entity.UserAuthority;
+import com.dadok.gaerval.integration_util.ServiceIntegration;
+import com.dadok.gaerval.testutil.BookObjectProvider;
+import com.dadok.gaerval.testutil.TestTimeHolder;
+import com.dadok.gaerval.testutil.UserObjectProvider;
+
+@Tag("Integration Test")
+@Sql(scripts = {"/sql/clean_up.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class BookGroupCommentServiceTest extends ServiceIntegration {
+
+	@Autowired
+	private BookGroupCommentService bookGroupCommentService;
+
+	@Autowired
+	private PlatformTransactionManager platformTransactionManager;
+
+	private User user;
+
+	private Book book;
+
+	private BookGroup bookGroup;
+
+	private GroupComment groupComment;
+
+	@BeforeEach
+	void setUp() {
+		TransactionStatus transaction = platformTransactionManager.getTransaction(new DefaultTransactionDefinition());
+		try {
+			Authority authority = authorityRepository.save(Authority.create(Role.USER));
+			User user = UserObjectProvider.createKakaoUser();
+			user.getAuthorities().add(UserAuthority.create(authority));
+			this.user = userRepository.save(user);
+			Book book = BookObjectProvider.createBook();
+			this.book = bookRepository.save(book);
+			BookGroup bookGroup = BookGroup.create(user.getId(),
+				book, LocalDate.now(), LocalDate.now().plusDays(7), 5,
+				"책모임", "책모임이에요", false, null, null, true,
+				passwordEncoder, TestTimeHolder.now());
+			this.bookGroup = bookGroupRepository.save(bookGroup);
+			GroupComment comment = GroupComment.create("내용", bookGroup, user);
+			this.groupComment = groupCommentRepository.save(comment);
+			platformTransactionManager.commit(transaction);
+		} catch (Exception e) {
+			platformTransactionManager.rollback(transaction);
+		}
+	}
+
+	@DisplayName("코멘트의 내용이 바뀐다.")
+	@Test
+	void updateBookGroupComment_success() {
+		//given
+		String changedContents = "바뀐 내용";
+		BookGroupCommentUpdateRequest commentUpdateRequest = new BookGroupCommentUpdateRequest(changedContents);
+		//when
+		bookGroupCommentService.updateBookGroupComment(bookGroup.getId(), user.getId(), groupComment.getId(),
+			commentUpdateRequest);
+		//then
+		GroupComment findGroupComment = groupCommentRepository.findById(groupComment.getId()).get();
+		assertEquals(findGroupComment.getContents(), changedContents);
+	}
+
+	@DisplayName("작성자가 아닌 사람이 요청하면, 예외를 던진다")
+	@Test
+	void updateBookGroupComment_throw() {
+		//given
+		String changedContents = "바뀐 내용";
+		BookGroupCommentUpdateRequest commentUpdateRequest = new BookGroupCommentUpdateRequest(changedContents);
+		Long otherUserId = 1000L;
+
+		//when
+		assertThrows(NotMatchedCommentAuthorException.class,
+			() -> bookGroupCommentService.updateBookGroupComment(bookGroup.getId(), otherUserId, groupComment.getId(),
+				commentUpdateRequest));
+		//then
+		GroupComment findGroupComment = groupCommentRepository.findById(groupComment.getId()).get();
+		assertNotEquals(findGroupComment.getContents(), changedContents);
+	}
+
+}

--- a/src/test/java/com/dadok/gaerval/integration_util/ServiceIntegration.java
+++ b/src/test/java/com/dadok/gaerval/integration_util/ServiceIntegration.java
@@ -5,9 +5,11 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.TestPropertySource;
 
 import com.dadok.gaerval.domain.book.repository.BookRepository;
+import com.dadok.gaerval.domain.book_group.repository.BookGroupCommentRepository;
 import com.dadok.gaerval.domain.book_group.repository.BookGroupRepository;
 import com.dadok.gaerval.domain.book_group.repository.GroupMemberRepository;
 import com.dadok.gaerval.domain.bookshelf.repository.BookshelfRepository;
@@ -64,6 +66,13 @@ public abstract class ServiceIntegration {
 	protected Authority getAuthority(Role role) {
 		return this.authorityRepository.getReferenceById(role);
 	}
+
+	@Autowired
+	protected PasswordEncoder passwordEncoder;
+
+	@Autowired
+	protected BookGroupCommentRepository groupCommentRepository;
+
 
 	// protected User kakaoUser;
 	//


### PR DESCRIPTION
### 🍀 목적
* 모임 댓글 수정, 삭제 버그 수정 

### ☕ 변경사항<!-- 있다면 적고 없다면 적지 않는다.-->
*  /api/book-groups/{groupId}/ comment -> comments 복수형으로 수정하였습니다
* path에 commentId를 추가하였습니다  
* body에서 commentId를 제거하였습니다.
* 요청자가 댓글의 주인이 아니라면, 403 응답를 반환합니다. 에러코드는 BGC9입니다.

### ❓ pr 포인트
* 트랜잭션에 신경써주세요.
* api path 규칙에 신경써주세요 
