### PR TITLE
refactor : 모임 댓글 리스트 조회 모임 공개여부 필드 포함하도록 수정

### DIFF
--- a/src/main/java/com/dadok/gaerval/domain/book_group/dto/response/BookGroupCommentResponses.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/dto/response/BookGroupCommentResponses.java
@@ -11,11 +11,19 @@ public record BookGroupCommentResponses(
 	int count, // 결과 총 갯수
 	boolean isEmpty, // 반환 값이 0개인가
 
+	BookGroupResponse bookGroup,
 	List<BookGroupCommentResponse> bookGroupComments) {
 
-	public BookGroupCommentResponses(Slice<BookGroupCommentResponse> slice) {
-		this(slice.isFirst(), slice.isLast(), slice.hasNext(), slice.getNumberOfElements(), slice.isEmpty(),
+	public BookGroupCommentResponses(Boolean isPublic, Slice<BookGroupCommentResponse> slice) {
+		this(slice.isFirst(),
+			slice.isLast(),
+			slice.hasNext(),
+			slice.getNumberOfElements(),
+			slice.isEmpty(),
+			new BookGroupResponse(isPublic),
 			slice.getContent());
 	}
 
+	public record BookGroupResponse(Boolean isPublic) {
+	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/book_group/repository/BookGroupCommentSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/repository/BookGroupCommentSupportImpl.java
@@ -6,6 +6,7 @@ import static com.dadok.gaerval.domain.user.entity.QUser.*;
 import static com.querydsl.core.types.Projections.*;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -15,6 +16,7 @@ import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentSearchReq
 import com.dadok.gaerval.domain.book_group.dto.response.BookGroupCommentResponse;
 import com.dadok.gaerval.domain.book_group.dto.response.BookGroupCommentResponses;
 import com.dadok.gaerval.global.util.QueryDslUtil;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -40,19 +42,20 @@ public class BookGroupCommentSupportImpl implements BookGroupCommentSupport {
 	public BookGroupCommentResponses findAllBy(BookGroupCommentSearchRequest request, Long userId, Long groupId) {
 		Sort.Direction direction = request.sortDirection().toDirection();
 
-		List<BookGroupCommentResponse> groupCommentResponses = queryFactory.select(
-				constructor(BookGroupCommentResponse.class,
-					groupComment.id.as("commentId"),
-					groupComment.contents.as("contents"),
-					bookGroup.id.as("booGroupId"),
-					groupComment.parentComment.id.as("parentCommentId"),
-					user.id.as("userId"),
-					user.profileImage.as("userProfileImage"),
-					groupComment.createdAt.as("createdAt"),
-					groupComment.modifiedAt.as("modifiedAt"),
-					user.nickname.nickname.as("nickname"),
-					Expressions.booleanTemplate("{0} = {1}", user.id, userId).as("writtenByCurrentUser")
-				))
+		List<Tuple> groupCommentTuples = queryFactory
+			.select(
+				groupComment.id.as("commentId"),
+				groupComment.contents.as("contents"),
+				bookGroup.id.as("bookGroupId"),
+				groupComment.parentComment.id.as("parentCommentId"),
+				user.id.as("userId"),
+				user.profileImage.as("userProfileImage"),
+				groupComment.createdAt.as("createdAt"),
+				groupComment.modifiedAt.as("modifiedAt"),
+				user.nickname.nickname.as("nickname"),
+				Expressions.booleanTemplate("{0} = {1}", user.id, userId).as("writtenByCurrentUser"),
+				bookGroup.isPublic
+			)
 			.from(groupComment)
 			.innerJoin(user).on(user.id.eq(groupComment.user.id))
 			.innerJoin(bookGroup).on(bookGroup.id.eq(groupComment.bookGroup.id))
@@ -64,10 +67,31 @@ public class BookGroupCommentSupportImpl implements BookGroupCommentSupport {
 			.limit(request.pageSize() + 1)
 			.fetch();
 
-		Slice<BookGroupCommentResponse> bookGroupResponses = QueryDslUtil.toSlice(groupCommentResponses,
+		List<BookGroupCommentResponse> bookGroupCommentResponses = groupCommentTuples.stream().map(
+			tuple -> new BookGroupCommentResponse(
+				tuple.get(groupComment.id),
+				tuple.get(groupComment.contents),
+				tuple.get(bookGroup.id),
+				tuple.get(groupComment.parentComment.id),
+				tuple.get(user.id),
+				tuple.get(user.profileImage),
+				tuple.get(groupComment.createdAt),
+				tuple.get(groupComment.modifiedAt),
+				tuple.get(user.nickname.nickname),
+				Objects.equals(tuple.get(user.id), userId))
+		).toList();
+
+		Boolean isPublic = null;
+
+		if (!groupCommentTuples.isEmpty()) {
+			Tuple tuple = groupCommentTuples.get(0);
+			isPublic = tuple.get(bookGroup.isPublic);
+		}
+
+		Slice<BookGroupCommentResponse> bookGroupResponses = QueryDslUtil.toSlice(bookGroupCommentResponses,
 			PageRequest.of(0, request.pageSize(), Sort.by(direction, "id")));
 
-		return new BookGroupCommentResponses(bookGroupResponses);
+		return new BookGroupCommentResponses(isPublic, bookGroupResponses);
 	}
 
 	@Override

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -735,7 +735,7 @@ Host: localhost:8080</code></pre>
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=5eb3793e-10c1-4c01-a485-e3c1282be770; Path=/; Max-Age=1209600; Expires=Sun, 26 Mar 2023 11:16:50 GMT; HttpOnly
+Set-Cookie: RefreshToken=95b1c741-01c1-42ba-9bf5-f52ee5d2eb21; Path=/; Max-Age=1209600; Expires=Sun, 26 Mar 2023 14:08:05 GMT; HttpOnly
 Location: https://localhost:3000/oauth/callback?access_token=Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJibGFja2RvZyIsImF1dGgiOlsiUk9MRV9VU0VSIl0sImVtYWlsIjoiYmxhY2tkb2dAYmxhY2tkb2cuY29tIiwiZXhwIjoxNjc3NTE2MTk0fQ.vREr5l-2vzr962PAToOT3mGjOrn6HS3moFukH4fGO1OHLAciGoXZoMZ4NKFP_Kqr8YNCO0rXYh2rDVUWYtmQIg</code></pre>
 </div>
 </div>
@@ -774,7 +774,7 @@ Location: https://localhost:3000/oauth/callback?access_token=Bearer eyJhbGciOiJI
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/token HTTP/1.1
 Host: localhost:8080
-Cookie: RefreshToken=0f4a8b1c-08df-4e0f-ae12-a56a92c34062</code></pre>
+Cookie: RefreshToken=186cda15-eea5-4d7f-b5f0-33405e3c8c4a</code></pre>
 </div>
 </div>
 </div>
@@ -807,7 +807,7 @@ Cookie: RefreshToken=0f4a8b1c-08df-4e0f-ae12-a56a92c34062</code></pre>
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMCIsImlkIjoxMCwicm9sZXMiOlsiVVNFUiJdLCJpYXQiOjE2Nzg2MTk3NjIsImlzcyI6ImRhZG9rIiwiZXhwIjoxNjc4NjI1NzYyfQ.3iOb-vp6ANKlsJk4X1PFAa08SLyskJ_FGnGqlHG_AIc</code></pre>
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMCIsImlkIjoxMCwicm9sZXMiOlsiVVNFUiJdLCJpYXQiOjE2Nzg2MzAwMDcsImlzcyI6ImRhZG9rIiwiZXhwIjoxNjc4NjM2MDA3fQ.3sM9Xk2v6R5mUSUUD-_wS3ELx0x7XErMhxprlikGktM</code></pre>
 </div>
 </div>
 </div>
@@ -850,7 +850,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMCIsImlkIjoxMCwicm9sZXMiO
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/logout HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWQiOjEsInJvbGVzIjpbIlVTRVIiXSwiaWF0IjoxNjc4NjE5NzYyLCJpc3MiOiJkYWRvayIsImV4cCI6MTY3ODYyNTc2Mn0.QqgQqLb9TttyyIYNDIknd8Ae57NSML34YqlKPwLDv3E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWQiOjEsInJvbGVzIjpbIlVTRVIiXSwiaWF0IjoxNjc4NjMwMDA3LCJpc3MiOiJkYWRvayIsImV4cCI6MTY3ODYzNjAwN30.HExpfj76qw4Mq5CIQJeiskmp-ZLDgR5aB1tr1pTDmug
 Host: localhost:8080
 Cookie: RefreshToken=null</code></pre>
 </div>
@@ -4026,8 +4026,8 @@ Content-Length: 1095
     "bookId" : 1,
     "userId" : 1,
     "userProfileImage" : "https://image.dadokcdn.dadok.io/abcdfgpe.jpg",
-    "createdAt" : "2023-03-12 20:16:10",
-    "modifiedAt" : "2023-03-12 20:16:10",
+    "createdAt" : "2023-03-12 23:07:03",
+    "modifiedAt" : "2023-03-12 23:07:03",
     "nickname" : "티나",
     "writtenByCurrentUser" : true
   }, {
@@ -4036,8 +4036,8 @@ Content-Length: 1095
     "bookId" : 1,
     "userId" : 2,
     "userProfileImage" : "https://image.dadokcdn.dadok.io/abcdfgpe.jpg",
-    "createdAt" : "2023-03-12 20:16:10",
-    "modifiedAt" : "2023-03-12 20:16:10",
+    "createdAt" : "2023-03-12 23:07:03",
+    "modifiedAt" : "2023-03-12 23:07:03",
     "nickname" : "0soo",
     "writtenByCurrentUser" : false
   }, {
@@ -4046,8 +4046,8 @@ Content-Length: 1095
     "bookId" : 1,
     "userId" : 3,
     "userProfileImage" : "https://image.dadokcdn.dadok.io/abcdfgpe.jpg",
-    "createdAt" : "2023-03-12 20:16:10",
-    "modifiedAt" : "2023-03-12 20:16:10",
+    "createdAt" : "2023-03-12 23:07:03",
+    "modifiedAt" : "2023-03-12 23:07:03",
     "nickname" : "foreverYoung",
     "writtenByCurrentUser" : false
   } ]
@@ -4401,7 +4401,7 @@ Content-Length: 323
   "userId" : 1,
   "userProfileImage" : "https://image.dadokcdn.dadok.io/abcdfgpe.jpg",
   "createdAt" : "2023-03-07 10:20:00",
-  "modifiedAt" : "2023-03-12 20:16:10",
+  "modifiedAt" : "2023-03-12 23:07:04",
   "nickname" : "티나",
   "writtenByCurrentUser" : true
 }</code></pre>
@@ -6214,7 +6214,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 1375
+Content-Length: 1420
 
 {
   "isFirst" : true,
@@ -6222,6 +6222,9 @@ Content-Length: 1375
   "hasNext" : false,
   "count" : 3,
   "isEmpty" : false,
+  "bookGroup" : {
+    "isPublic" : true
+  },
   "bookGroupComments" : [ {
     "commentId" : 123,
     "contents" : "미움받을 용기 좋아요",
@@ -6229,8 +6232,8 @@ Content-Length: 1375
     "parentCommentId" : 234,
     "userId" : 123,
     "userProfileImage" : "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg",
-    "createdAt" : "2023-03-12 20:16:15",
-    "modifiedAt" : "2023-03-12 20:16:15",
+    "createdAt" : "2023-03-12 23:07:12",
+    "modifiedAt" : "2023-03-12 23:07:12",
     "nickname" : "티나",
     "writtenByCurrentUser" : true
   }, {
@@ -6240,8 +6243,8 @@ Content-Length: 1375
     "parentCommentId" : 234,
     "userId" : 234,
     "userProfileImage" : "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg",
-    "createdAt" : "2023-03-12 20:16:15",
-    "modifiedAt" : "2023-03-12 20:16:15",
+    "createdAt" : "2023-03-12 23:07:12",
+    "modifiedAt" : "2023-03-12 23:07:12",
     "nickname" : "0Soo",
     "writtenByCurrentUser" : false
   }, {
@@ -6251,8 +6254,8 @@ Content-Length: 1375
     "parentCommentId" : 234,
     "userId" : 456,
     "userProfileImage" : "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg",
-    "createdAt" : "2023-03-12 20:16:15",
-    "modifiedAt" : "2023-03-12 20:16:15",
+    "createdAt" : "2023-03-12 23:07:12",
+    "modifiedAt" : "2023-03-12 23:07:12",
     "nickname" : "youngijang",
     "writtenByCurrentUser" : false
   } ]
@@ -6307,6 +6310,12 @@ Content-Length: 1375
 <td class="tableblock halign-left valign-top"><p class="tableblock">다음 데이터 존재 여부</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookGroup.isPublic</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 공개 여부</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookGroupComments[]</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
@@ -6334,7 +6343,7 @@ Content-Length: 1375
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookGroupComments[].parentCommentId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">부모 댓 ID</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">부모 댓글 ID</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>bookGroupComments[].userId</code></p></td>

--- a/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentControllerSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentControllerSliceTest.java
@@ -96,6 +96,7 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 		List<BookGroupCommentResponse> bookGroupCommentResponseList = BookGroupCommentObjectProvider.mockCommentResponses;
 
 		BookGroupCommentResponses bookGroupCommentResponses = new BookGroupCommentResponses(
+			true,
 			QueryDslUtil.toSlice(bookGroupCommentResponseList, PageRequest.of(0, 10)));
 
 		given(bookGroupCommentService.findAllBookGroupCommentsByGroup(eq(request), any(), any()))
@@ -138,12 +139,13 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 					fieldWithPath("isFirst").description("첫 번째 페이지 여부").type(JsonFieldType.BOOLEAN),
 					fieldWithPath("isLast").description("마지막 페이지 여부").type(JsonFieldType.BOOLEAN),
 					fieldWithPath("hasNext").description("다음 데이터 존재 여부").type(JsonFieldType.BOOLEAN),
+					fieldWithPath("bookGroup.isPublic").description("모임 공개 여부").optional().type(JsonFieldType.BOOLEAN),
 					fieldWithPath("bookGroupComments[]").type(JsonFieldType.ARRAY).description("댓글 목록"),
 					fieldWithPath("bookGroupComments[].commentId").type(JsonFieldType.NUMBER).description("댓글 ID"),
 					fieldWithPath("bookGroupComments[].contents").type(JsonFieldType.STRING).description("댓글 내용"),
 					fieldWithPath("bookGroupComments[].bookGroupId").type(JsonFieldType.NUMBER).description("모임 ID"),
 					fieldWithPath("bookGroupComments[].parentCommentId").type(JsonFieldType.NUMBER)
-						.description("부모 댓 ID"),
+						.description("부모 댓글 ID"),
 					fieldWithPath("bookGroupComments[].userId").type(JsonFieldType.NUMBER).description("사용자 ID"),
 					fieldWithPath("bookGroupComments[].userProfileImage").type(JsonFieldType.STRING)
 						.description("사용자 프로필 이미지"),

--- a/src/test/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentServiceSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentServiceSliceTest.java
@@ -77,6 +77,7 @@ class BookGroupCommentServiceSliceTest {
 			)));
 
 		BookGroupCommentResponses bookGroupCommentResponses = new BookGroupCommentResponses(
+			true,
 			commentResponses);
 
 		given(bookGroupCommentRepository.findAllBy(request, 234L, 234L))


### PR DESCRIPTION
### 🍀 목적
* 모임 댓글 리스트 조회시 모임 공개여부 필드 포함하도록 수정 
* with @WooDaeHyun 
