### PR TITLE
[#117 ]익명사용자 접근을 위한 empty user 구현

### DIFF
--- a/src/main/java/com/dadok/gaerval/domain/book/api/BookCommentController.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/api/BookCommentController.java
@@ -28,6 +28,7 @@ import com.dadok.gaerval.domain.book.dto.response.BookCommentResponse;
 import com.dadok.gaerval.domain.book.dto.response.BookCommentResponses;
 import com.dadok.gaerval.domain.book.service.BookCommentService;
 import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentDeleteRequest;
+import com.dadok.gaerval.global.config.security.CurrentUserPrincipal;
 import com.dadok.gaerval.global.config.security.UserPrincipal;
 
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BookCommentController {
 
 	private final BookCommentService bookCommentService;
+
 	/**
 	 * <pre>
 	 *     도서 ID를 통해 코멘트 목록을 가져온다.
@@ -52,11 +54,12 @@ public class BookCommentController {
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER', 'ROLE_ANONYMOUS')")
 	public ResponseEntity<BookCommentResponses> findBookComments(
 		@PathVariable(name = "bookId") Long bookId,
-		@AuthenticationPrincipal UserPrincipal userPrincipal,
-		@ModelAttribute  @Valid BookCommentSearchRequest bookCommentSearchRequest
+		@CurrentUserPrincipal UserPrincipal userPrincipal,
+		@ModelAttribute @Valid BookCommentSearchRequest bookCommentSearchRequest
 	) {
 		log.info("[BookCommentController]-[BookCommentResponses]-bookId : {}", bookId);
-		return ResponseEntity.ok().body(bookCommentService.findBookCommentsBy(bookId, userPrincipal.getUserId(), bookCommentSearchRequest));
+		return ResponseEntity.ok()
+			.body(bookCommentService.findBookCommentsBy(bookId, userPrincipal.getUserId(), bookCommentSearchRequest));
 	}
 
 	/**
@@ -73,13 +76,14 @@ public class BookCommentController {
 		@PathVariable Long bookId,
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@Valid @RequestBody BookCommentCreateRequest bookCommentCreateRequest) {
-		log.info("[BookCommentController]-[BookCommentIdResponse]-bookCommentCreateRequest : {}", bookCommentCreateRequest);
-		Long commentId = bookCommentService.createBookComment(bookId, userPrincipal.getUserId(), bookCommentCreateRequest);
+		log.info("[BookCommentController]-[BookCommentIdResponse]-bookCommentCreateRequest : {}",
+			bookCommentCreateRequest);
+		Long commentId = bookCommentService.createBookComment(bookId, userPrincipal.getUserId(),
+			bookCommentCreateRequest);
 		String redirectUri =
 			ServletUriComponentsBuilder.fromCurrentRequestUri().toUriString() + "/" + commentId.toString();
 		return ResponseEntity.created(URI.create(redirectUri)).body(new BookCommentIdResponse(commentId));
 	}
-
 
 	/**
 	 * <pre>
@@ -96,10 +100,10 @@ public class BookCommentController {
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@Valid @RequestBody BookCommentUpdateRequest bookCommentUpdateRequest) {
 		log.info("[BookController]-[BookCommentResponse]-bookCommentUpdateRequest : {}", bookCommentUpdateRequest);
-		BookCommentResponse bookCommentResponse = bookCommentService.updateBookComment(bookId, userPrincipal.getUserId(), bookCommentUpdateRequest);
+		BookCommentResponse bookCommentResponse = bookCommentService.updateBookComment(bookId,
+			userPrincipal.getUserId(), bookCommentUpdateRequest);
 		return ResponseEntity.ok().body(bookCommentResponse);
 	}
-
 
 	/**
 	 * <pre>
@@ -115,7 +119,8 @@ public class BookCommentController {
 		@PathVariable Long bookId,
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@Valid @RequestBody BookGroupCommentDeleteRequest bookGroupCommentDeleteRequest) {
-		log.info("[BookController]-[BookCommentResponse]-bookGroupCommentDeleteRequest : {}", bookGroupCommentDeleteRequest);
+		log.info("[BookController]-[BookCommentResponse]-bookGroupCommentDeleteRequest : {}",
+			bookGroupCommentDeleteRequest);
 		bookCommentService.deleteBookComment(bookId, userPrincipal.getUserId(), bookGroupCommentDeleteRequest);
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/dadok/gaerval/domain/book/api/BookController.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/api/BookController.java
@@ -8,7 +8,6 @@ import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,6 +26,7 @@ import com.dadok.gaerval.domain.book.dto.response.BookResponses;
 import com.dadok.gaerval.domain.book.dto.response.SuggestionsBookFindResponses;
 import com.dadok.gaerval.domain.book.dto.response.UserByBookResponses;
 import com.dadok.gaerval.domain.book.service.BookService;
+import com.dadok.gaerval.global.config.security.CurrentUserPrincipal;
 import com.dadok.gaerval.global.config.security.UserPrincipal;
 
 import lombok.RequiredArgsConstructor;
@@ -52,7 +52,6 @@ public class BookController {
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER','ROLE_ANONYMOUS')")
 	public ResponseEntity<BookResponses> findBooksByQuery(@RequestParam(name = "query") String query) {
 		log.info("[BookController]-[findBooksByQuery]-query : {}", query);
-
 		return ResponseEntity.ok().body(bookService.findAllByKeyword(query));
 	}
 
@@ -84,7 +83,7 @@ public class BookController {
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER','ROLE_ANONYMOUS')")
 	public ResponseEntity<UserByBookResponses> findUsersByBook(
 		@PathVariable(name = "bookId") Long bookId,
-		@AuthenticationPrincipal UserPrincipal userPrincipal) {
+		@CurrentUserPrincipal UserPrincipal userPrincipal) {
 		return ResponseEntity.ok().body(bookService.findUserByBookId(bookId, userPrincipal.getUserId()));
 	}
 

--- a/src/main/java/com/dadok/gaerval/domain/book/repository/BookCommentSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/repository/BookCommentSupportImpl.java
@@ -3,6 +3,7 @@ package com.dadok.gaerval.domain.book.repository;
 import static com.dadok.gaerval.domain.book.entity.QBook.*;
 import static com.dadok.gaerval.domain.book.entity.QBookComment.*;
 import static com.dadok.gaerval.domain.user.entity.QUser.*;
+import static com.dadok.gaerval.global.util.QueryDslUtil.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -46,7 +47,7 @@ public class BookCommentSupportImpl implements BookCommentSupport {
 					bookComment.createdAt.as("createdAt"),
 					bookComment.modifiedAt.as("modifiedAt"),
 					user.nickname.nickname.as("nickname"),
-					Expressions.booleanTemplate("{0} = {1}", user.id, userId).as("writtenByCurrentUser")
+					generateNullableBooleanExpression(user.id, userId).as("writtenByCurrentUser")
 				))
 			.from(bookComment)
 			.innerJoin(user).on(user.id.eq(bookComment.user.id))

--- a/src/main/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentController.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentController.java
@@ -27,6 +27,7 @@ import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentUpdateReq
 import com.dadok.gaerval.domain.book_group.dto.response.BookGroupCommentResponse;
 import com.dadok.gaerval.domain.book_group.dto.response.BookGroupCommentResponses;
 import com.dadok.gaerval.domain.book_group.service.BookGroupCommentService;
+import com.dadok.gaerval.global.config.security.CurrentUserPrincipal;
 import com.dadok.gaerval.global.config.security.UserPrincipal;
 
 import lombok.RequiredArgsConstructor;
@@ -66,19 +67,20 @@ public class BookGroupCommentController {
 	 * 모임의 댓글 조회
 	 * </Pre>
 	 *
-	 * @param groupId   모임 아이디
+	 * @param groupId 모임 아이디
 	 * @return status : ok, BookGroupCommentResponses 조회된 모임 댓글 list
 	 */
-	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+	@PreAuthorize(value = "hasAnyRole('ROLE_ANONYMOUS','ROLE_ADMIN', 'ROLE_USER')")
 	@GetMapping(value = "/{groupId}/comments", produces = APPLICATION_JSON_VALUE)
 	public ResponseEntity<BookGroupCommentResponses> findBookGroupsComment(
 		@PathVariable Long groupId,
-		@AuthenticationPrincipal UserPrincipal userPrincipal,
+		@CurrentUserPrincipal UserPrincipal userPrincipal,
 		@ModelAttribute @Valid BookGroupCommentSearchRequest bookGroupCommentSearchRequest
 	) {
-		return ResponseEntity.ok().body(bookGroupCommentService.findAllBookGroupCommentsByGroup(bookGroupCommentSearchRequest,userPrincipal.getUserId(), groupId));
+		return ResponseEntity.ok()
+			.body(bookGroupCommentService.findAllBookGroupCommentsByGroup(bookGroupCommentSearchRequest,
+				userPrincipal.getUserId(), groupId));
 	}
-
 
 	/**
 	 * <Pre>

--- a/src/main/java/com/dadok/gaerval/domain/book_group/api/BookGroupController.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/api/BookGroupController.java
@@ -28,6 +28,7 @@ import com.dadok.gaerval.domain.book_group.dto.response.BookGroupDetailResponse;
 import com.dadok.gaerval.domain.book_group.dto.response.BookGroupIdResponse;
 import com.dadok.gaerval.domain.book_group.dto.response.BookGroupResponses;
 import com.dadok.gaerval.domain.book_group.service.BookGroupService;
+import com.dadok.gaerval.global.config.security.CurrentUserPrincipal;
 import com.dadok.gaerval.global.config.security.UserPrincipal;
 
 import lombok.RequiredArgsConstructor;
@@ -68,11 +69,11 @@ public class BookGroupController {
 		return ResponseEntity.created(URI.create(redirectUri)).body(new BookGroupIdResponse(bookGroupId));
 	}
 
-	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+	@PreAuthorize(value = "hasAnyRole('ROLE_ANONYMOUS','ROLE_ADMIN', 'ROLE_USER')")
 	@GetMapping("/{groupId}")
 	public ResponseEntity<BookGroupDetailResponse> findBookGroup(
 		@PathVariable Long groupId,
-		@AuthenticationPrincipal UserPrincipal userPrincipal) {
+		@CurrentUserPrincipal UserPrincipal userPrincipal) {
 		return ResponseEntity.ok(bookGroupService.findGroup(userPrincipal.getUserId(), groupId));
 	}
 

--- a/src/main/java/com/dadok/gaerval/domain/book_group/dto/response/BookGroupCommentResponses.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/dto/response/BookGroupCommentResponses.java
@@ -14,16 +14,16 @@ public record BookGroupCommentResponses(
 	BookGroupResponse bookGroup,
 	List<BookGroupCommentResponse> bookGroupComments) {
 
-	public BookGroupCommentResponses(Boolean isPublic, Slice<BookGroupCommentResponse> slice) {
+	public BookGroupCommentResponses(Boolean isPublic, Boolean isGroupMember, Slice<BookGroupCommentResponse> slice) {
 		this(slice.isFirst(),
 			slice.isLast(),
 			slice.hasNext(),
 			slice.getNumberOfElements(),
 			slice.isEmpty(),
-			new BookGroupResponse(isPublic),
+			new BookGroupResponse(isPublic, isGroupMember),
 			slice.getContent());
 	}
 
-	public record BookGroupResponse(Boolean isPublic) {
+	public record BookGroupResponse(Boolean isPublic, Boolean isGroupMember) {
 	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/book_group/repository/BookGroupCommentSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/book_group/repository/BookGroupCommentSupportImpl.java
@@ -3,6 +3,7 @@ package com.dadok.gaerval.domain.book_group.repository;
 import static com.dadok.gaerval.domain.book_group.entity.QBookGroup.*;
 import static com.dadok.gaerval.domain.book_group.entity.QGroupComment.*;
 import static com.dadok.gaerval.domain.user.entity.QUser.*;
+import static com.dadok.gaerval.global.util.QueryDslUtil.*;
 import static com.querydsl.core.types.Projections.*;
 
 import java.util.List;
@@ -51,7 +52,7 @@ public class BookGroupCommentSupportImpl implements BookGroupCommentSupport {
 					groupComment.createdAt.as("createdAt"),
 					groupComment.modifiedAt.as("modifiedAt"),
 					user.nickname.nickname.as("nickname"),
-					Expressions.booleanTemplate("{0} = {1}", user.id, userId).as("writtenByCurrentUser")
+					generateNullableBooleanExpression(user.id, userId).as("writtenByCurrentUser")
 				))
 			.from(groupComment)
 			.innerJoin(user).on(user.id.eq(groupComment.user.id))

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfController.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfController.java
@@ -155,7 +155,8 @@ public class BookshelfController {
 	@GetMapping(value = "/bookshelves/{bookshelvesId}/books",
 		consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ANONYMOUS','ROLE_ADMIN', 'ROLE_USER')")
-	public ResponseEntity<BookInShelfResponses> findBooksInBookShelf(@PathVariable Long bookshelvesId,
+	public ResponseEntity<BookInShelfResponses> findBooksInBookShelf(
+		@PathVariable Long bookshelvesId,
 		@ModelAttribute @Valid BooksInBookShelfFindRequest request
 	) {
 		BookInShelfResponses bookInShelfResponses = bookshelfService.findAllBooksInShelf(bookshelvesId, request);
@@ -165,7 +166,8 @@ public class BookshelfController {
 
 	@PreAuthorize(value = "hasAnyRole('ROLE_ANONYMOUS','ROLE_ADMIN', 'ROLE_USER')")
 	@GetMapping(value = "/bookshelves", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
-	public ResponseEntity<BookShelfDetailResponse> findBookShelfWithUserJob(@RequestParam @Valid @NotNull Long userId) {
+	public ResponseEntity<BookShelfDetailResponse> findBookShelfWithUserJob(
+		@RequestParam @Valid @NotNull Long userId) {
 
 		BookShelfDetailResponse bookShelf = bookshelfService.findBookShelfWithJob(userId);
 
@@ -174,10 +176,9 @@ public class BookshelfController {
 
 	@PreAuthorize(value = "hasAnyRole('ROLE_ANONYMOUS','ROLE_ADMIN', 'ROLE_USER')")
 	@GetMapping(value = "/bookshelves/{bookshelfId}", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
-	public ResponseEntity<BookShelfDetailResponse> findBookshelfById(@PathVariable Long bookshelfId) {
-
+	public ResponseEntity<BookShelfDetailResponse> findBookshelfById(
+		@PathVariable Long bookshelfId) {
 		BookShelfDetailResponse bookShelf = bookshelfService.findBookShelfById(bookshelfId);
-
 		return ResponseEntity.ok(bookShelf);
 	}
 

--- a/src/main/java/com/dadok/gaerval/global/config/security/CurrentUserPrincipal.java
+++ b/src/main/java/com/dadok/gaerval/global/config/security/CurrentUserPrincipal.java
@@ -1,0 +1,17 @@
+package com.dadok.gaerval.global.config.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+/**
+ * @See anonymousUser 경우 EmptyUserPrincipal 저장
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? new com.dadok.gaerval.global.config.security.EmptyUserPrincipal() : #this")
+public @interface CurrentUserPrincipal {
+}

--- a/src/main/java/com/dadok/gaerval/global/config/security/EmptyUserPrincipal.java
+++ b/src/main/java/com/dadok/gaerval/global/config/security/EmptyUserPrincipal.java
@@ -1,0 +1,17 @@
+package com.dadok.gaerval.global.config.security;
+
+import java.util.List;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public class EmptyUserPrincipal extends UserPrincipal {
+
+	public EmptyUserPrincipal() {
+		super(0L, null, List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+	}
+
+	@Override
+	public Long getUserId() {
+		return null;
+	}
+}

--- a/src/main/java/com/dadok/gaerval/global/config/security/UserPrincipal.java
+++ b/src/main/java/com/dadok/gaerval/global/config/security/UserPrincipal.java
@@ -20,13 +20,13 @@ public class UserPrincipal
 
 	private Map<String, Object> attributes;
 
-	private UserPrincipal(Long userId, Collection<GrantedAuthority> authorities) {
+	protected UserPrincipal(Long userId, Collection<GrantedAuthority> authorities) {
 		super(userId.toString(), "", authorities);
 		this.userId = userId;
 		this.authorities = authorities;
 	}
 
-	private UserPrincipal(Long userId, String accessToken, Collection<GrantedAuthority> authorities) {
+	protected UserPrincipal(Long userId, String accessToken, Collection<GrantedAuthority> authorities) {
 		super(userId.toString(), "", authorities);
 		this.userId = userId;
 		this.authorities = authorities;

--- a/src/main/java/com/dadok/gaerval/global/util/QueryDslUtil.java
+++ b/src/main/java/com/dadok/gaerval/global/util/QueryDslUtil.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Sort;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberPath;
 
 import lombok.AccessLevel;
@@ -60,6 +61,13 @@ public class QueryDslUtil {
 
 	public static OrderSpecifier<?> getOrder(NumberPath<Long> id, Sort.Direction direction) {
 		return direction.isDescending() ? id.desc() : id.asc();
+	}
+
+	public static BooleanExpression generateNullableBooleanExpression(NumberPath<Long> entityId, Long id) {
+		if (id == null) {
+			return Expressions.asBoolean(false);
+		}
+		return Expressions.booleanTemplate("{0} = {1}", entityId, id);
 	}
 
 }

--- a/src/main/resources/static/docs/common/authProvider.html
+++ b/src/main/resources/static/docs/common/authProvider.html
@@ -495,7 +495,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.8.1<br>
-Last updated 2023-03-01 21:37:33 +0900
+Last updated 2023-03-02 03:27:52 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/common/bookshelfItemType.html
+++ b/src/main/resources/static/docs/common/bookshelfItemType.html
@@ -491,7 +491,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.8.1<br>
-Last updated 2023-03-01 13:09:38 +0900
+Last updated 2023-03-02 03:27:52 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/common/errorCode.html
+++ b/src/main/resources/static/docs/common/errorCode.html
@@ -625,7 +625,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.8.1<br>
-Last updated 2023-03-11 15:09:30 +0900
+Last updated 2023-03-11 17:52:37 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/common/gender.html
+++ b/src/main/resources/static/docs/common/gender.html
@@ -499,7 +499,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.8.1<br>
-Last updated 2023-03-01 13:09:38 +0900
+Last updated 2023-03-02 03:27:52 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/common/jobGroup.html
+++ b/src/main/resources/static/docs/common/jobGroup.html
@@ -583,7 +583,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.8.1<br>
-Last updated 2023-03-01 13:09:38 +0900
+Last updated 2023-03-02 03:27:42 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/common/jobName.html
+++ b/src/main/resources/static/docs/common/jobName.html
@@ -2335,7 +2335,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.8.1<br>
-Last updated 2023-03-01 13:09:38 +0900
+Last updated 2023-03-02 03:27:42 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/common/sortDirection.html
+++ b/src/main/resources/static/docs/common/sortDirection.html
@@ -495,7 +495,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.8.1<br>
-Last updated 2023-03-02 18:22:38 +0900
+Last updated 2023-03-02 03:27:52 +0900
 </div>
 </div>
 </body>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -735,7 +735,7 @@ Host: localhost:8080</code></pre>
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Set-Cookie: RefreshToken=5eb3793e-10c1-4c01-a485-e3c1282be770; Path=/; Max-Age=1209600; Expires=Sun, 26 Mar 2023 11:16:50 GMT; HttpOnly
+Set-Cookie: RefreshToken=18257d57-bc12-4e8c-8f9c-ebd341fe04a0; Path=/; Max-Age=1209600; Expires=Sun, 26 Mar 2023 15:26:34 GMT; HttpOnly
 Location: https://localhost:3000/oauth/callback?access_token=Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJibGFja2RvZyIsImF1dGgiOlsiUk9MRV9VU0VSIl0sImVtYWlsIjoiYmxhY2tkb2dAYmxhY2tkb2cuY29tIiwiZXhwIjoxNjc3NTE2MTk0fQ.vREr5l-2vzr962PAToOT3mGjOrn6HS3moFukH4fGO1OHLAciGoXZoMZ4NKFP_Kqr8YNCO0rXYh2rDVUWYtmQIg</code></pre>
 </div>
 </div>
@@ -774,30 +774,15 @@ Location: https://localhost:3000/oauth/callback?access_token=Bearer eyJhbGciOiJI
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/token HTTP/1.1
 Host: localhost:8080
-Cookie: RefreshToken=0f4a8b1c-08df-4e0f-ae12-a56a92c34062</code></pre>
+Cookie: RefreshToken=f4567e9f-e546-47e8-bd27-83e9aea71b57</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
 <h4 id="_request_header_cookie"><a class="link" href="#_request_header_cookie">Request Header Cookie</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>RefreshToken</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">리프레시 토큰 쿠키 이름</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::/Users/jang-yeongji/Documents/dev-workspace/Team-Gaerval-Dadok-BE/build/generated-snippets/auth-controller-slice-test/refresh-access-token/request-headers.adoc[]</p>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_response_2"><a class="link" href="#_response_2">Response</a></h4>
@@ -807,7 +792,7 @@ Cookie: RefreshToken=0f4a8b1c-08df-4e0f-ae12-a56a92c34062</code></pre>
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMCIsImlkIjoxMCwicm9sZXMiOlsiVVNFUiJdLCJpYXQiOjE2Nzg2MTk3NjIsImlzcyI6ImRhZG9rIiwiZXhwIjoxNjc4NjI1NzYyfQ.3iOb-vp6ANKlsJk4X1PFAa08SLyskJ_FGnGqlHG_AIc</code></pre>
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMCIsImlkIjoxMCwicm9sZXMiOlsiVVNFUiJdLCJpYXQiOjE2Nzg2MzQ3MjUsImlzcyI6ImRhZG9rIiwiZXhwIjoxNjc4NjQwNzI1fQ.IRzTUnY8z4tgKErCf9pvt8h2PI01ngX1HEaL91wC2RE</code></pre>
 </div>
 </div>
 </div>
@@ -850,7 +835,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMCIsImlkIjoxMCwicm9sZXMiO
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/logout HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWQiOjEsInJvbGVzIjpbIlVTRVIiXSwiaWF0IjoxNjc4NjE5NzYyLCJpc3MiOiJkYWRvayIsImV4cCI6MTY3ODYyNTc2Mn0.QqgQqLb9TttyyIYNDIknd8Ae57NSML34YqlKPwLDv3E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWQiOjEsInJvbGVzIjpbIlVTRVIiXSwiaWF0IjoxNjc4NjM0NzI1LCJpc3MiOiJkYWRvayIsImV4cCI6MTY3ODY0MDcyNX0.sFtVbc82Cdm6NdueJjUK48GPD5f9FE68XU7dvB_Y1rI
 Host: localhost:8080
 Cookie: RefreshToken=null</code></pre>
 </div>
@@ -3938,7 +3923,6 @@ Content-Length: 18
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/books/1/comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJibGFja2RvZyIsImF1dGgiOlsiUk9MRV9VU0VSIl0sImVtYWlsIjoiYmxhY2tkb2dAYmxhY2tkb2cuY29tIiwiZXhwIjoxNjc3NTE2MTk0fQ.vREr5l-2vzr962PAToOT3mGjOrn6HS3moFukH4fGO1OHLAciGoXZoMZ4NKFP_Kqr8YNCO0rXYh2rDVUWYtmQIg
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -4026,8 +4010,8 @@ Content-Length: 1095
     "bookId" : 1,
     "userId" : 1,
     "userProfileImage" : "https://image.dadokcdn.dadok.io/abcdfgpe.jpg",
-    "createdAt" : "2023-03-12 20:16:10",
-    "modifiedAt" : "2023-03-12 20:16:10",
+    "createdAt" : "2023-03-13 00:25:43",
+    "modifiedAt" : "2023-03-13 00:25:43",
     "nickname" : "티나",
     "writtenByCurrentUser" : true
   }, {
@@ -4036,8 +4020,8 @@ Content-Length: 1095
     "bookId" : 1,
     "userId" : 2,
     "userProfileImage" : "https://image.dadokcdn.dadok.io/abcdfgpe.jpg",
-    "createdAt" : "2023-03-12 20:16:10",
-    "modifiedAt" : "2023-03-12 20:16:10",
+    "createdAt" : "2023-03-13 00:25:43",
+    "modifiedAt" : "2023-03-13 00:25:43",
     "nickname" : "0soo",
     "writtenByCurrentUser" : false
   }, {
@@ -4046,8 +4030,8 @@ Content-Length: 1095
     "bookId" : 1,
     "userId" : 3,
     "userProfileImage" : "https://image.dadokcdn.dadok.io/abcdfgpe.jpg",
-    "createdAt" : "2023-03-12 20:16:10",
-    "modifiedAt" : "2023-03-12 20:16:10",
+    "createdAt" : "2023-03-13 00:25:43",
+    "modifiedAt" : "2023-03-13 00:25:43",
     "nickname" : "foreverYoung",
     "writtenByCurrentUser" : false
   } ]
@@ -4401,7 +4385,7 @@ Content-Length: 323
   "userId" : 1,
   "userProfileImage" : "https://image.dadokcdn.dadok.io/abcdfgpe.jpg",
   "createdAt" : "2023-03-07 10:20:00",
-  "modifiedAt" : "2023-03-12 20:16:10",
+  "modifiedAt" : "2023-03-13 00:25:43",
   "nickname" : "티나",
   "writtenByCurrentUser" : true
 }</code></pre>
@@ -4608,8 +4592,8 @@ Host: localhost:8080
 {
   "bookId" : 123,
   "title" : "소모임 화이팅",
-  "startDate" : "2023-03-12",
-  "endDate" : "2023-03-14",
+  "startDate" : "2023-03-13",
+  "endDate" : "2023-03-15",
   "maxMemberCount" : 5,
   "introduce" : "우리끼리 옹기종기",
   "hasJoinPasswd" : true,
@@ -4819,7 +4803,7 @@ Host: localhost:8080
 {
   "title" : "책읽기 소모임",
   "introduce" : "변경하고 싶은 내용",
-  "endDate" : "2023-03-16",
+  "endDate" : "2023-03-17",
   "maxMemberCount" : 4
 }</code></pre>
 </div>
@@ -5083,8 +5067,8 @@ Content-Length: 580
   "bookGroupId" : 999,
   "title" : "김영한님 JPA 읽으실분",
   "introduce" : "우리모임은 JPA 책 스터디를 하려고 모여있어요",
-  "startDate" : "2023-03-13",
-  "endDate" : "2023-03-19",
+  "startDate" : "2023-03-14",
+  "endDate" : "2023-03-20",
   "hasJoinPasswd" : false,
   "joinQuestion" : "영한님 생일은?",
   "isPublic" : true,
@@ -5332,8 +5316,8 @@ Content-Length: 2659
     "bookGroupId" : 999,
     "title" : "모임999",
     "introduce" : "모임 999에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-13",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-14",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : true,
     "isPublic" : false,
@@ -5352,8 +5336,8 @@ Content-Length: 2659
     "bookGroupId" : 997,
     "title" : "모임997",
     "introduce" : "모임 997에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-12",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-13",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : true,
     "isPublic" : false,
@@ -5372,8 +5356,8 @@ Content-Length: 2659
     "bookGroupId" : 995,
     "title" : "모임995",
     "introduce" : "모임 995에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-12",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-13",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : true,
     "isPublic" : true,
@@ -5392,8 +5376,8 @@ Content-Length: 2659
     "bookGroupId" : 994,
     "title" : "모임994",
     "introduce" : "모임 994에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-12",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-13",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : false,
     "isPublic" : true,
@@ -5412,8 +5396,8 @@ Content-Length: 2659
     "bookGroupId" : 993,
     "title" : "모임993",
     "introduce" : "모임 993에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-12",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-13",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : false,
     "isPublic" : false,
@@ -5677,8 +5661,8 @@ Content-Length: 2659
     "bookGroupId" : 999,
     "title" : "모임999",
     "introduce" : "모임 999에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-13",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-14",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : true,
     "isPublic" : false,
@@ -5697,8 +5681,8 @@ Content-Length: 2659
     "bookGroupId" : 997,
     "title" : "모임997",
     "introduce" : "모임 997에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-12",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-13",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : true,
     "isPublic" : false,
@@ -5717,8 +5701,8 @@ Content-Length: 2659
     "bookGroupId" : 995,
     "title" : "모임995",
     "introduce" : "모임 995에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-12",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-13",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : true,
     "isPublic" : true,
@@ -5737,8 +5721,8 @@ Content-Length: 2659
     "bookGroupId" : 994,
     "title" : "모임994",
     "introduce" : "모임 994에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-12",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-13",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : false,
     "isPublic" : true,
@@ -5757,8 +5741,8 @@ Content-Length: 2659
     "bookGroupId" : 993,
     "title" : "모임993",
     "introduce" : "모임 993에용",
-    "startDate" : "2023-03-12",
-    "endDate" : "2023-03-12",
+    "startDate" : "2023-03-13",
+    "endDate" : "2023-03-13",
     "maxMemberCount" : 5,
     "hasJoinPasswd" : false,
     "isPublic" : false,
@@ -6229,8 +6213,8 @@ Content-Length: 1375
     "parentCommentId" : 234,
     "userId" : 123,
     "userProfileImage" : "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg",
-    "createdAt" : "2023-03-12 20:16:15",
-    "modifiedAt" : "2023-03-12 20:16:15",
+    "createdAt" : "2023-03-13 00:25:53",
+    "modifiedAt" : "2023-03-13 00:25:53",
     "nickname" : "티나",
     "writtenByCurrentUser" : true
   }, {
@@ -6240,8 +6224,8 @@ Content-Length: 1375
     "parentCommentId" : 234,
     "userId" : 234,
     "userProfileImage" : "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg",
-    "createdAt" : "2023-03-12 20:16:15",
-    "modifiedAt" : "2023-03-12 20:16:15",
+    "createdAt" : "2023-03-13 00:25:53",
+    "modifiedAt" : "2023-03-13 00:25:53",
     "nickname" : "0Soo",
     "writtenByCurrentUser" : false
   }, {
@@ -6251,8 +6235,8 @@ Content-Length: 1375
     "parentCommentId" : 234,
     "userId" : 456,
     "userProfileImage" : "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg",
-    "createdAt" : "2023-03-12 20:16:15",
-    "modifiedAt" : "2023-03-12 20:16:15",
+    "createdAt" : "2023-03-13 00:25:53",
+    "modifiedAt" : "2023-03-13 00:25:53",
     "nickname" : "youngijang",
     "writtenByCurrentUser" : false
   } ]
@@ -8150,7 +8134,7 @@ Content-Length: 210
 <div id="footer">
 <div id="footer-text">
 Version 0.8.1<br>
-Last updated 2023-03-12 20:00:21 +0900
+Last updated 2023-03-12 21:51:42 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/dadok/gaerval/domain/book/api/BookCommentControllerTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/api/BookCommentControllerTest.java
@@ -79,7 +79,6 @@ class BookCommentControllerTest extends ControllerSliceTest {
 		// when
 		mockMvc.perform(get("/api/books/{bookId}/comments", 1L)
 				.contentType(MediaType.APPLICATION_JSON)
-				.header(ACCESS_TOKEN_HEADER_NAME, MOCK_ACCESS_TOKEN)
 				.accept(MediaType.APPLICATION_JSON)
 			).andExpect(status().isOk())
 			.andDo(this.restDocs.document(

--- a/src/test/java/com/dadok/gaerval/domain/book/service/BookCommentServiceSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/service/BookCommentServiceSliceTest.java
@@ -1,4 +1,4 @@
- package com.dadok.gaerval.domain.book.service;
+package com.dadok.gaerval.domain.book.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -35,7 +35,7 @@ import com.dadok.gaerval.testutil.BookObjectProvider;
 import com.dadok.gaerval.testutil.UserObjectProvider;
 
 @ExtendWith(MockitoExtension.class)
-class DefaultBookCommentServiceTest {
+class BookCommentServiceSliceTest {
 
 	@Mock
 	private BookCommentRepository bookCommentRepository;
@@ -130,7 +130,7 @@ class DefaultBookCommentServiceTest {
 			bookGroupCommentDeleteRequest);
 
 		// then
-		verify(bookCommentRepository).findByBookIdAndUserId(1L,1L);
+		verify(bookCommentRepository).findByBookIdAndUserId(1L, 1L);
 		verify(bookCommentRepository).delete(comment);
 	}
 
@@ -207,14 +207,12 @@ class DefaultBookCommentServiceTest {
 
 		List<BookCommentResponse> bookComments = BookCommentObjectProvider.createMockResponses();
 
-
 		Slice<BookCommentResponse> bookFindResponses = QueryDslUtil.toSlice(bookComments,
 			PageRequest.of(0, 50, Sort.by(
 				Sort.Direction.DESC, "comment_id"
 			)));
 
-
-		given(bookCommentRepository.findAllComments(1L, 1L,bookCommentSearchRequest)).willReturn(
+		given(bookCommentRepository.findAllComments(1L, 1L, bookCommentSearchRequest)).willReturn(
 			new BookCommentResponses(bookFindResponses));
 
 		// when

--- a/src/test/java/com/dadok/gaerval/domain/book/service/BookCommentServiceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/service/BookCommentServiceTest.java
@@ -61,12 +61,12 @@ public class BookCommentServiceTest extends IntegrationTest {
 		BookCommentSearchRequest request = new BookCommentSearchRequest(5, null, SortDirection.DESC);
 		//when
 		BookCommentResponses responses = bookCommentService.findBookCommentsBy(book.getId(),
-			user.getId(), request);
+			null, request);
 		//then
 		assertEquals(responses.count(), 1);
 		assertEquals(responses.bookComments().get(0).getContents(), bookComment.getComment());
 		assertEquals(responses.bookComments().get(0).getNickname(), user.getNickname().nickname());
-		assertEquals(responses.bookComments().get(0).getWrittenByCurrentUser(), true);
+		assertEquals(responses.bookComments().get(0).getWrittenByCurrentUser(), false);
 	}
 
 }

--- a/src/test/java/com/dadok/gaerval/domain/book/service/BookCommentServiceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/service/BookCommentServiceTest.java
@@ -1,0 +1,72 @@
+package com.dadok.gaerval.domain.book.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.dadok.gaerval.domain.book.dto.request.BookCommentSearchRequest;
+import com.dadok.gaerval.domain.book.dto.response.BookCommentResponses;
+import com.dadok.gaerval.domain.book.entity.Book;
+import com.dadok.gaerval.domain.book.entity.BookComment;
+import com.dadok.gaerval.domain.user.entity.User;
+import com.dadok.gaerval.global.util.SortDirection;
+import com.dadok.gaerval.integration_util.IntegrationTest;
+
+@Tag("Integration Test")
+@Sql(scripts = {"/sql/book_comment/book_comment_data.sql"}, executionPhase =
+	Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "/sql/clean_up.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+public class BookCommentServiceTest extends IntegrationTest {
+
+	@Autowired
+	private BookCommentService bookCommentService;
+
+	private User user;
+
+	private Book book;
+
+	private BookComment bookComment;
+
+	@BeforeEach
+	void setUp() {
+		this.user = userRepository.findById(1L).get();
+		this.book = bookRepository.findById(1L).get();
+		this.bookComment = bookCommentRepository.findById(1L).get();
+	}
+
+	@DisplayName("모임에 관한 코멘트 리스트를 받아온다. - 성공")
+	@Test
+	void findAllBookGroupCommentsByGroup_success() {
+		//given
+		BookCommentSearchRequest request = new BookCommentSearchRequest(5, null, SortDirection.DESC);
+		//when
+		BookCommentResponses responses = bookCommentService.findBookCommentsBy(book.getId(),
+			user.getId(), request);
+		//then
+		assertEquals(responses.count(), 1);
+		assertEquals(responses.bookComments().get(0).getContents(), bookComment.getComment());
+		assertEquals(responses.bookComments().get(0).getNickname(), user.getNickname().nickname());
+		assertEquals(responses.bookComments().get(0).getWrittenByCurrentUser(), true);
+	}
+
+	@DisplayName("사용자가 null일때 모임에 관한 코멘트 리스트를 받아온다. - 성공")
+	@Test
+	void findAllBookGroupCommentsByGroup_nullUserId_success() {
+		//given
+		BookCommentSearchRequest request = new BookCommentSearchRequest(5, null, SortDirection.DESC);
+		//when
+		BookCommentResponses responses = bookCommentService.findBookCommentsBy(book.getId(),
+			user.getId(), request);
+		//then
+		assertEquals(responses.count(), 1);
+		assertEquals(responses.bookComments().get(0).getContents(), bookComment.getComment());
+		assertEquals(responses.bookComments().get(0).getNickname(), user.getNickname().nickname());
+		assertEquals(responses.bookComments().get(0).getWrittenByCurrentUser(), true);
+	}
+
+}

--- a/src/test/java/com/dadok/gaerval/domain/book/service/BookServiceSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/service/BookServiceSliceTest.java
@@ -35,7 +35,7 @@ import com.dadok.gaerval.global.util.QueryDslUtil;
 import com.dadok.gaerval.testutil.BookObjectProvider;
 
 @ExtendWith(MockitoExtension.class)
-class DefaultBookServiceSliceTest {
+class BookServiceSliceTest {
 
 	@InjectMocks
 	private DefaultBookService defaultBookService;

--- a/src/test/java/com/dadok/gaerval/domain/book/service/BookServiceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/service/BookServiceTest.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
-class DefaultBookServiceTest {
+class BookServiceTest {
 
 	@Mock
 	private ExternalBookApiOperations externalBookApiOperations;

--- a/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentControllerSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentControllerSliceTest.java
@@ -96,7 +96,7 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 		List<BookGroupCommentResponse> bookGroupCommentResponseList = BookGroupCommentObjectProvider.mockCommentResponses;
 
 		BookGroupCommentResponses bookGroupCommentResponses = new BookGroupCommentResponses(
-			true,
+			true, true,
 			QueryDslUtil.toSlice(bookGroupCommentResponseList, PageRequest.of(0, 10)));
 
 		given(bookGroupCommentService.findAllBookGroupCommentsByGroup(eq(request), any(), any()))
@@ -139,6 +139,9 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 					fieldWithPath("isLast").description("마지막 페이지 여부").type(JsonFieldType.BOOLEAN),
 					fieldWithPath("hasNext").description("다음 데이터 존재 여부").type(JsonFieldType.BOOLEAN),
 					fieldWithPath("bookGroup.isPublic").description("모임 공개 여부").optional().type(JsonFieldType.BOOLEAN),
+					fieldWithPath("bookGroup.isGroupMember").description("요청자가 모임에 속해있는 유저인지 여부")
+						.optional()
+						.type(JsonFieldType.BOOLEAN),
 					fieldWithPath("bookGroupComments[]").type(JsonFieldType.ARRAY).description("댓글 목록"),
 					fieldWithPath("bookGroupComments[].commentId").type(JsonFieldType.NUMBER).description("댓글 ID"),
 					fieldWithPath("bookGroupComments[].contents").type(JsonFieldType.STRING).description("댓글 내용"),

--- a/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentControllerSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupCommentControllerSliceTest.java
@@ -113,7 +113,6 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 			.andDo(print())
 			.andDo(this.restDocs.document(
 				requestHeaders(
-					headerWithName(ACCESS_TOKEN_HEADER_NAME).description(ACCESS_TOKEN_HEADER_NAME_DESCRIPTION),
 					headerWithName(HttpHeaders.CONTENT_TYPE).description(CONTENT_TYPE_JSON_DESCRIPTION)
 				),
 				pathParameters(
@@ -169,7 +168,6 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 		willDoNothing().given(bookGroupCommentService)
 			.updateBookGroupComment(groupId, 1L, bookGroupCommentId, request);
 
-
 		// when then
 		mockMvc.perform(patch("/api/book-groups/{groupId}/comments/{commentId}", groupId, bookGroupCommentId)
 				.contentType(MediaType.APPLICATION_JSON)
@@ -198,7 +196,6 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 
 	}
 
-
 	@DisplayName("댓글 삭제에 성공한다.")
 	@Test
 	void deleteBookGroupComment_ShouldReturnOk() throws Exception {
@@ -209,7 +206,6 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 		BookGroupCommentDeleteRequest request = new BookGroupCommentDeleteRequest(bookGroupCommentId);
 
 		doNothing().when(bookGroupCommentService).deleteBookGroupComment(groupId, 1L, request);
-
 
 		// when then
 		mockMvc.perform(delete("/api/book-groups/{groupId}/comments", groupId)
@@ -236,7 +232,6 @@ class BookGroupCommentControllerSliceTest extends ControllerSliceTest {
 						)
 				)
 			));
-
 
 	}
 }

--- a/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupControllerSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book_group/api/BookGroupControllerSliceTest.java
@@ -386,7 +386,6 @@ class BookGroupControllerSliceTest extends ControllerSliceTest {
 			).andExpect(status().isOk())
 			.andDo(this.restDocs.document(
 					requestHeaders(
-						headerWithName(ACCESS_TOKEN_HEADER_NAME).description(ACCESS_TOKEN_HEADER_NAME_DESCRIPTION),
 						headerWithName(HttpHeaders.CONTENT_TYPE).description(CONTENT_TYPE_JSON_DESCRIPTION)
 					),
 					pathParameters(

--- a/src/test/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentServiceSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentServiceSliceTest.java
@@ -77,7 +77,7 @@ class BookGroupCommentServiceSliceTest {
 			)));
 
 		BookGroupCommentResponses bookGroupCommentResponses = new BookGroupCommentResponses(
-			true,
+			true, true,
 			commentResponses);
 
 		given(bookGroupCommentRepository.findAllBy(request, 234L, 234L))

--- a/src/test/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentServiceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book_group/service/BookGroupCommentServiceTest.java
@@ -9,11 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
+import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentSearchRequest;
 import com.dadok.gaerval.domain.book_group.dto.request.BookGroupCommentUpdateRequest;
+import com.dadok.gaerval.domain.book_group.dto.response.BookGroupCommentResponses;
 import com.dadok.gaerval.domain.book_group.entity.BookGroup;
 import com.dadok.gaerval.domain.book_group.entity.GroupComment;
 import com.dadok.gaerval.domain.book_group.exception.NotMatchedCommentAuthorException;
 import com.dadok.gaerval.domain.user.entity.User;
+import com.dadok.gaerval.global.util.SortDirection;
 import com.dadok.gaerval.integration_util.IntegrationTest;
 
 @Tag("Integration Test")
@@ -52,7 +55,7 @@ class BookGroupCommentServiceTest extends IntegrationTest {
 		assertEquals(findGroupComment.getContents(), changedContents);
 	}
 
-	@DisplayName("작성자가 아닌 사람이 요청하면, 예외를 던진다")
+	@DisplayName("작성자가 아닌 사람이 수정 요청하면, 예외를 던진다")
 	@Test
 	void updateBookGroupComment_throw() {
 		//given
@@ -67,6 +70,36 @@ class BookGroupCommentServiceTest extends IntegrationTest {
 		//then
 		GroupComment findGroupComment = groupCommentRepository.findById(groupComment.getId()).get();
 		assertNotEquals(findGroupComment.getContents(), changedContents);
+	}
+
+	@DisplayName("모임에 관한 코멘트 리스트를 받아온다. - 성공")
+	@Test
+	void findAllBookGroupCommentsByGroup_success() {
+		//given
+		BookGroupCommentSearchRequest request = new BookGroupCommentSearchRequest(5, null, SortDirection.DESC);
+		//when
+		BookGroupCommentResponses responses = bookGroupCommentService.findAllBookGroupCommentsByGroup(request,
+			user.getId(), bookGroup.getId());
+		//then
+		assertEquals(responses.count(), 1);
+		assertEquals(responses.bookGroupComments().get(0).getContents(), groupComment.getContents());
+		assertEquals(responses.bookGroupComments().get(0).getNickname(), user.getNickname().nickname());
+		assertEquals(responses.bookGroupComments().get(0).getWrittenByCurrentUser(), true);
+	}
+
+	@DisplayName("사용자가 null일때 모임에 관한 코멘트 리스트를 받아온다. - 성공")
+	@Test
+	void findAllBookGroupCommentsByGroup_nullUserId_success() {
+		//given
+		BookGroupCommentSearchRequest request = new BookGroupCommentSearchRequest(5, null, SortDirection.DESC);
+		//when
+		BookGroupCommentResponses responses = bookGroupCommentService.findAllBookGroupCommentsByGroup(request,
+			null, bookGroup.getId());
+		//then
+		assertEquals(responses.count(), 1);
+		assertEquals(responses.bookGroupComments().get(0).getContents(), groupComment.getContents());
+		assertEquals(responses.bookGroupComments().get(0).getNickname(), user.getNickname().nickname());
+		assertEquals(responses.bookGroupComments().get(0).getWrittenByCurrentUser(), false);
 	}
 
 }

--- a/src/test/java/com/dadok/gaerval/integration_util/IntegrationTest.java
+++ b/src/test/java/com/dadok/gaerval/integration_util/IntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.dadok.gaerval.domain.auth.repository.RefreshTokenRepository;
 import com.dadok.gaerval.domain.auth.service.RefreshTokenService;
+import com.dadok.gaerval.domain.book.repository.BookCommentRepository;
 import com.dadok.gaerval.domain.book.repository.BookRepository;
 import com.dadok.gaerval.domain.book_group.repository.BookGroupCommentRepository;
 import com.dadok.gaerval.domain.book_group.repository.BookGroupRepository;
@@ -70,6 +71,9 @@ public abstract class IntegrationTest {
 	protected BookRepository bookRepository;
 
 	@Autowired
+	protected BookCommentRepository bookCommentRepository;
+
+	@Autowired
 	protected BookGroupRepository bookGroupRepository;
 
 	@Autowired
@@ -93,7 +97,6 @@ public abstract class IntegrationTest {
 
 	@Autowired
 	private RedisConnectionFactory redisConnectionFactory;
-
 
 	protected void redisCleanUp() {
 		RedisConnection connection = redisConnectionFactory.getConnection();

--- a/src/test/resources/sql/book_comment/book_comment_data.sql
+++ b/src/test/resources/sql/book_comment/book_comment_data.sql
@@ -1,0 +1,34 @@
+insert into authorities
+    (created_at, modified_at, name)
+values (now(), now(), 'USER');
+
+insert into users
+(id, created_at, modified_at, auth_id, auth_provider,
+ birthday, email, gender, job_id, name, nickname, oauth_nickname, profile_image)
+values (1, now(), now(), 'abcdfgh123', 'KAKAO', NULL, 'dadok@kakao.com', 'NONE', NULL, NULL, '다독이카카오', '책장왕다독이',
+        'https://image.dadokcdn.dadok.io/abcdfgpe.jpg');
+
+insert into users
+(id, created_at, modified_at, auth_id, auth_provider,
+ birthday, email, gender, job_id, name, nickname, oauth_nickname, profile_image)
+values (2, now(), now(), 'abcdfgh123', 'NAVER', NULL, 'dadok1@naver.com', 'NONE', NULL, NULL, '다독이네이버', '책장왕다독이',
+        'https://image.dadokcdn.dadok.io/abcdfgpe.jpg');
+
+
+insert into user_authorities
+    (created_at, modified_at, authority, user_id)
+values (now(), now(), 'USER', 1);
+
+insert into user_authorities
+    (created_at, modified_at, authority, user_id)
+values (now(), now(), 'USER', 2);
+
+insert into books
+(id, api_provider, author, contents, image_key, image_url, is_deleted, isbn, publisher, title, url)
+values (1, 'KAKAO', '기시미 이치로, 고가 후미타케', '인간은 변할 수 있고, 누구나 행복해 질 수 있다. 단 그러기 위해서는 ‘용기’가 필요하다고 말한 철학자가 있다.', NULL,
+        'https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F1467038',
+        false, '9788996991342', '인플루엔셜', '미움받을 용기',
+        'https://search.daum.net/search?w=bookpage&bookId=1467038&q=%EB%AF%B8%EC%9B%80%EB%B0%9B%EC%9D%84+%EC%9A%A9%EA%B8%B0');
+
+insert into book_comments(comment, book_id, user_id, created_at, modified_at)
+    value ('하이룽~!', 1,1,now(),null);


### PR DESCRIPTION
<!--제목은 `[#이슈번호] 이슈 제목` 으로 작성한다.-->

### 🍀 목적
- 익명사용자 접근가능 api 수정
- 익명사용자용 empty user 구현
- queryDsl null 일경우 fales 반환 exprssion 추가

#117 #120 