### PR TITLE
refact : http 로깅 AOP 적용

### DIFF
--- a/src/main/java/com/dadok/gaerval/domain/book/api/BookCommentController.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/api/BookCommentController.java
@@ -27,6 +27,7 @@ import com.dadok.gaerval.domain.book.dto.response.BookCommentIdResponse;
 import com.dadok.gaerval.domain.book.dto.response.BookCommentResponse;
 import com.dadok.gaerval.domain.book.dto.response.BookCommentResponses;
 import com.dadok.gaerval.domain.book.service.BookCommentService;
+import com.dadok.gaerval.global.common.logging.LogHttpRequests;
 import com.dadok.gaerval.global.config.security.CurrentUserPrincipal;
 import com.dadok.gaerval.global.config.security.UserPrincipal;
 
@@ -51,12 +52,12 @@ public class BookCommentController {
 	 */
 	@GetMapping(value = "/{bookId}/comments", produces = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER', 'ROLE_ANONYMOUS')")
+	@LogHttpRequests
 	public ResponseEntity<BookCommentResponses> findBookComments(
 		@PathVariable(name = "bookId") Long bookId,
 		@CurrentUserPrincipal UserPrincipal userPrincipal,
 		@ModelAttribute @Valid BookCommentSearchRequest bookCommentSearchRequest
 	) {
-		log.info("[BookCommentController]-[BookCommentResponses]-bookId : {}", bookId);
 		return ResponseEntity.ok()
 			.body(bookCommentService.findBookCommentsBy(bookId, userPrincipal.getUserId(), bookCommentSearchRequest));
 	}
@@ -71,12 +72,11 @@ public class BookCommentController {
 	 */
 	@PostMapping(value = "/{bookId}/comments", consumes = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+	@LogHttpRequests
 	public ResponseEntity<BookCommentIdResponse> saveBookComment(
 		@PathVariable Long bookId,
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@Valid @RequestBody BookCommentCreateRequest bookCommentCreateRequest) {
-		log.info("[BookCommentController]-[BookCommentIdResponse]-bookCommentCreateRequest : {}",
-			bookCommentCreateRequest);
 		Long commentId = bookCommentService.createBookComment(bookId, userPrincipal.getUserId(),
 			bookCommentCreateRequest);
 		String redirectUri =
@@ -94,11 +94,11 @@ public class BookCommentController {
 	 */
 	@PatchMapping(value = "/{bookId}/comments", consumes = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+	@LogHttpRequests
 	public ResponseEntity<BookCommentResponse> modifyBookComment(
 		@PathVariable Long bookId,
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@Valid @RequestBody BookCommentUpdateRequest bookCommentUpdateRequest) {
-		log.info("[BookController]-[BookCommentResponse]-bookCommentUpdateRequest : {}", bookCommentUpdateRequest);
 		BookCommentResponse bookCommentResponse = bookCommentService.updateBookComment(bookId,
 			userPrincipal.getUserId(), bookCommentUpdateRequest);
 		return ResponseEntity.ok().body(bookCommentResponse);
@@ -114,11 +114,10 @@ public class BookCommentController {
 	 */
 	@DeleteMapping(value = "/{bookId}/comments/{commentId}", consumes = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+	@LogHttpRequests
 	public ResponseEntity<Void> deleteBookComment(
 		@PathVariable Long bookId, @PathVariable Long commentId,
 		@AuthenticationPrincipal UserPrincipal userPrincipal) {
-		log.info("[BookController]-[BookCommentResponse]-commentId : {}",
-			commentId);
 		bookCommentService.deleteBookComment(bookId, userPrincipal.getUserId(), commentId);
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/dadok/gaerval/domain/book/api/BookController.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/api/BookController.java
@@ -26,6 +26,7 @@ import com.dadok.gaerval.domain.book.dto.response.BookResponses;
 import com.dadok.gaerval.domain.book.dto.response.SuggestionsBookFindResponses;
 import com.dadok.gaerval.domain.book.dto.response.UserByBookResponses;
 import com.dadok.gaerval.domain.book.service.BookService;
+import com.dadok.gaerval.global.common.logging.LogHttpRequests;
 import com.dadok.gaerval.global.config.security.CurrentUserPrincipal;
 import com.dadok.gaerval.global.config.security.UserPrincipal;
 
@@ -50,8 +51,8 @@ public class BookController {
 	 */
 	@GetMapping(produces = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER','ROLE_ANONYMOUS')")
+	@LogHttpRequests
 	public ResponseEntity<BookResponses> findBooksByQuery(@RequestParam(name = "query") String query) {
-		log.info("[BookController]-[findBooksByQuery]-query : {}", query);
 		return ResponseEntity.ok().body(bookService.findAllByKeyword(query));
 	}
 
@@ -65,8 +66,8 @@ public class BookController {
 	 */
 	@GetMapping(value = "/{bookId}", produces = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER','ROLE_ANONYMOUS')")
+	@LogHttpRequests
 	public ResponseEntity<BookResponse> findBookDetail(@PathVariable(name = "bookId") Long bookId) {
-		log.info("[BookController]-[BookResponse]-bookId : {}", bookId);
 		return ResponseEntity.ok().body(bookService.findDetailById(bookId));
 	}
 
@@ -81,6 +82,7 @@ public class BookController {
 	 */
 	@GetMapping(value = "/{bookId}/users", produces = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER','ROLE_ANONYMOUS')")
+	@LogHttpRequests
 	public ResponseEntity<UserByBookResponses> findUsersByBook(
 		@PathVariable(name = "bookId") Long bookId,
 		@CurrentUserPrincipal UserPrincipal userPrincipal) {
@@ -97,8 +99,8 @@ public class BookController {
 	 */
 	@PostMapping(value = "", consumes = APPLICATION_JSON_VALUE)
 	@PreAuthorize(value = "hasAnyRole('ROLE_ANONYMOUS', 'ROLE_ADMIN', 'ROLE_USER')")
+	@LogHttpRequests
 	public ResponseEntity<BookIdResponse> saveBookDetail(@Valid @RequestBody BookCreateRequest bookCreateRequest) {
-		log.info("[BookController]-[Void]-bookCreateRequest : {}", bookCreateRequest);
 		Long bookId = bookService.createBookAndReturnId(bookCreateRequest);
 		String redirectUri =
 			ServletUriComponentsBuilder.fromCurrentRequestUri().toUriString() + "/" + bookId.toString();

--- a/src/main/java/com/dadok/gaerval/global/common/logging/LogHttpRequests.java
+++ b/src/main/java/com/dadok/gaerval/global/common/logging/LogHttpRequests.java
@@ -1,0 +1,11 @@
+package com.dadok.gaerval.global.common.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LogHttpRequests {
+}

--- a/src/main/java/com/dadok/gaerval/global/common/logging/LoggingAspect.java
+++ b/src/main/java/com/dadok/gaerval/global/common/logging/LoggingAspect.java
@@ -1,0 +1,36 @@
+package com.dadok.gaerval.global.common.logging;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class LoggingAspect {
+
+	private static final Logger log = LoggerFactory.getLogger(LoggingAspect.class);
+
+	@Before("@annotation(com.dadok.gaerval.global.common.logging.LogHttpRequests) && execution(public * *(..)))")
+	public void logHttpRequest(JoinPoint joinPoint) {
+		String controllerClassName = joinPoint.getTarget().getClass().getSimpleName();
+		String returnType = ((MethodSignature) joinPoint.getSignature()).getReturnType().getSimpleName();
+		Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+		String methodName = method.getName();
+		Parameter[] parameters = method.getParameters();
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < parameters.length; i++) {
+			Parameter parameter = parameters[i];
+			Object value = joinPoint.getArgs()[i];
+			sb.append(parameter.getName()).append("=").append(value).append("|");
+		}
+
+		log.info("[{}]-[{}]-[{}]-[{}]", controllerClassName, returnType, methodName, sb);
+	}
+}

--- a/src/main/java/com/dadok/gaerval/global/common/logging/LoggingAspect.java
+++ b/src/main/java/com/dadok/gaerval/global/common/logging/LoggingAspect.java
@@ -8,15 +8,15 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Aspect
 @Component
+@Slf4j
 public class LoggingAspect {
 
-	private static final Logger log = LoggerFactory.getLogger(LoggingAspect.class);
 
 	@Before("@annotation(com.dadok.gaerval.global.common.logging.LogHttpRequests) && execution(public * *(..)))")
 	public void logHttpRequest(JoinPoint joinPoint) {

--- a/src/main/java/com/dadok/gaerval/global/common/logging/LoggingAspect.java
+++ b/src/main/java/com/dadok/gaerval/global/common/logging/LoggingAspect.java
@@ -17,16 +17,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class LoggingAspect {
 
-
 	@Before("@annotation(com.dadok.gaerval.global.common.logging.LogHttpRequests) && execution(public * *(..)))")
 	public void logHttpRequest(JoinPoint joinPoint) {
 		String controllerClassName = joinPoint.getTarget().getClass().getSimpleName();
-		MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+		MethodSignature methodSignature = (MethodSignature)joinPoint.getSignature();
 		String returnType = methodSignature.getReturnType().getSimpleName();
 		Type genericReturnType = methodSignature.getMethod().getGenericReturnType();
 		if (genericReturnType instanceof ParameterizedType) {
 			ParameterizedType parameterizedType;
-			parameterizedType = (ParameterizedType) genericReturnType;
+			parameterizedType = (ParameterizedType)genericReturnType;
 			Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 			if (actualTypeArguments.length > 0 && actualTypeArguments[0] instanceof Class) {
 				returnType = ((Class)actualTypeArguments[0]).getSimpleName();
@@ -37,8 +36,12 @@ public class LoggingAspect {
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < parameters.length; i++) {
 			Parameter parameter = parameters[i];
-			Object value = joinPoint.getArgs()[i];
-			sb.append(parameter.getName()).append("=").append(value).append("|");
+			String value = joinPoint.getArgs()[i].toString();
+			String parameterName = parameter.getName();
+			if (value.startsWith("com.dadok")) {
+				value = value.substring(value.lastIndexOf('.') + 1);
+			}
+			sb.append(parameterName).append("=").append(value).append("|");
 		}
 
 		log.info("[{}]-[{}]-[{}]-[{}]", controllerClassName, returnType, methodName, sb);

--- a/src/main/java/com/dadok/gaerval/global/common/logging/LoggingAspect.java
+++ b/src/main/java/com/dadok/gaerval/global/common/logging/LoggingAspect.java
@@ -1,7 +1,8 @@
 package com.dadok.gaerval.global.common.logging;
 
-import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
@@ -20,10 +21,19 @@ public class LoggingAspect {
 	@Before("@annotation(com.dadok.gaerval.global.common.logging.LogHttpRequests) && execution(public * *(..)))")
 	public void logHttpRequest(JoinPoint joinPoint) {
 		String controllerClassName = joinPoint.getTarget().getClass().getSimpleName();
-		String returnType = ((MethodSignature) joinPoint.getSignature()).getReturnType().getSimpleName();
-		Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
-		String methodName = method.getName();
-		Parameter[] parameters = method.getParameters();
+		MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+		String returnType = methodSignature.getReturnType().getSimpleName();
+		Type genericReturnType = methodSignature.getMethod().getGenericReturnType();
+		if (genericReturnType instanceof ParameterizedType) {
+			ParameterizedType parameterizedType;
+			parameterizedType = (ParameterizedType) genericReturnType;
+			Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+			if (actualTypeArguments.length > 0 && actualTypeArguments[0] instanceof Class) {
+				returnType = ((Class)actualTypeArguments[0]).getSimpleName();
+			}
+		}
+		String methodName = methodSignature.getName();
+		Parameter[] parameters = methodSignature.getMethod().getParameters();
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < parameters.length; i++) {
 			Parameter parameter = parameters[i];


### PR DESCRIPTION
<!--제목은 `[#이슈번호] 이슈 제목` 으로 작성한다.-->

### 🍀 목적
- 로깅 시 AOP를 적용해 boilderplate 코드를 줄이기 위함

### 🌹 추가사항<!-- 있다면 적고 없다면 적지 않는다.-->
- LoggingAspect
- LogHttpRequests

### ☕ 변경사항<!-- 있다면 적고 없다면 적지 않는다.-->
- `log.info` 사용하던 Controller의 로깅 방식 변경

### ❓ pr 포인트
- 출력 포맷 어떤가요 
아래와 같은 형태로 출력됩니다.
```
[BookCommentController]-[BookCommentResponses]-[findBookComments]-[bookId=1|userPrincipal=com.dadok.gaerval.global.config.security.EmptyUserPrincipal [Username=0, Password=[PROTECTED], Enabled=true, AccountNonExpired=true, credentialsNonExpired=true, AccountNonLocked=true, Granted Authorities=[ROLE_ANONYMOUS]]|bookCommentSearchRequest=BookCommentSearchRequest[pageSize=10, bookCommentCursorId=null, sortDirection=DESC]|]
```

