### PR TITLE
[#151]fix : enum 참조 방식 변경

### DIFF
--- a/src/main/java/com/dadok/gaerval/domain/book/exception/AlreadyContainBookCommentException.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/exception/AlreadyContainBookCommentException.java
@@ -1,19 +1,19 @@
 package com.dadok.gaerval.domain.book.exception;
 
+import com.dadok.gaerval.global.common.JacocoExcludeGenerated;
 import com.dadok.gaerval.global.error.ErrorCode;
 import com.dadok.gaerval.global.error.exception.BusinessException;
 
+import lombok.Getter;
+
+@JacocoExcludeGenerated
 public class AlreadyContainBookCommentException extends BusinessException {
+	@Getter
+	private final ErrorCode errorCode;
 
-	private final ErrorCode errorCode = ErrorCode.ALREADY_CONTAIN_BOOK_COMMENT_MEMBER;
-
-	public AlreadyContainBookCommentException() {
-		super(ErrorCode.ALREADY_CONTAIN_BOOK_COMMENT_MEMBER);
-	}
-
-	@Override
-	public ErrorCode getErrorCode() {
-		return errorCode;
+	public AlreadyContainBookCommentException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
 	}
 
 }

--- a/src/main/java/com/dadok/gaerval/domain/book/exception/AlreadyContainBookCommentException.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/exception/AlreadyContainBookCommentException.java
@@ -6,7 +6,6 @@ import com.dadok.gaerval.global.error.exception.BusinessException;
 
 import lombok.Getter;
 
-@JacocoExcludeGenerated
 public class AlreadyContainBookCommentException extends BusinessException {
 	@Getter
 	private final ErrorCode errorCode;

--- a/src/main/java/com/dadok/gaerval/domain/book/exception/BookApiNotAvailableException.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/exception/BookApiNotAvailableException.java
@@ -3,10 +3,9 @@ package com.dadok.gaerval.domain.book.exception;
 import com.dadok.gaerval.global.error.ErrorCode;
 import com.dadok.gaerval.global.error.exception.BusinessException;
 
-
 public class BookApiNotAvailableException extends BusinessException {
 
-	private ErrorCode errorCode;
+	private final ErrorCode errorCode;
 
 	public BookApiNotAvailableException(ErrorCode errorCode) {
 		super(errorCode);

--- a/src/main/java/com/dadok/gaerval/domain/book/exception/InvalidBookDataException.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/exception/InvalidBookDataException.java
@@ -6,7 +6,6 @@ import com.dadok.gaerval.global.error.exception.BusinessException;
 
 import lombok.Getter;
 
-@JacocoExcludeGenerated
 public class InvalidBookDataException extends BusinessException {
 	@Getter
 	private final ErrorCode errorCode;

--- a/src/main/java/com/dadok/gaerval/domain/book/exception/NotMarkedBookException.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/exception/NotMarkedBookException.java
@@ -6,7 +6,6 @@ import com.dadok.gaerval.global.error.exception.BusinessException;
 
 import lombok.Getter;
 
-@JacocoExcludeGenerated
 public class NotMarkedBookException extends BusinessException {
 
 	@Getter

--- a/src/main/java/com/dadok/gaerval/domain/book/exception/NotMarkedBookException.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/exception/NotMarkedBookException.java
@@ -1,16 +1,19 @@
 package com.dadok.gaerval.domain.book.exception;
 
+import com.dadok.gaerval.global.common.JacocoExcludeGenerated;
 import com.dadok.gaerval.global.error.ErrorCode;
 import com.dadok.gaerval.global.error.exception.BusinessException;
 
+import lombok.Getter;
+
+@JacocoExcludeGenerated
 public class NotMarkedBookException extends BusinessException {
 
-	public NotMarkedBookException() {
-		super(ErrorCode.INVALID_COMMENT_NOT_BOOKMARK);
-	}
+	@Getter
+	private final ErrorCode errorCode;
 
-	@Override
-	public ErrorCode getErrorCode() {
-		return this.getErrorCode();
+	public NotMarkedBookException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
 	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/book/repository/BookSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/repository/BookSupportImpl.java
@@ -60,7 +60,6 @@ public class BookSupportImpl implements BookSupport {
 			PageRequest.of(0, request.pageSize(),
 				Sort.by(direction, "bookshelfItem.book_id")));
 
-
 		return new SuggestionsBookFindResponses(books, request.jobGroup());
 	}
 

--- a/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookCommentService.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookCommentService.java
@@ -20,6 +20,7 @@ import com.dadok.gaerval.domain.book_group.exception.NotMatchedCommentAuthorExce
 import com.dadok.gaerval.domain.bookshelf.service.BookshelfService;
 import com.dadok.gaerval.domain.user.entity.User;
 import com.dadok.gaerval.domain.user.service.UserService;
+import com.dadok.gaerval.global.error.ErrorCode;
 import com.dadok.gaerval.global.error.exception.ResourceNotfoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -46,10 +47,10 @@ public class DefaultBookCommentService implements BookCommentService {
 		boolean existsBookmark = bookshelfService.existsByUserIdAndBookId(userId, bookId);
 
 		if(!existsBookmark) {
-			throw new NotMarkedBookException();
+			throw new NotMarkedBookException(ErrorCode.INVALID_COMMENT_NOT_BOOKMARK);
 		}
 		if (existsComment) {
-			throw new AlreadyContainBookCommentException();
+			throw new AlreadyContainBookCommentException(ErrorCode.ALREADY_CONTAIN_BOOK_COMMENT_MEMBER);
 		} else {
 			BookComment newBookComment = BookComment.create(user, book, bookCommentCreateRequest.comment());
 			return bookCommentRepository.save(newBookComment).getId();
@@ -82,7 +83,7 @@ public class DefaultBookCommentService implements BookCommentService {
 		boolean existsBookmark = bookshelfService.existsByUserIdAndBookId(userId, bookId);
 
 		if(!existsBookmark) {
-			throw new NotMarkedBookException();
+			throw new NotMarkedBookException(ErrorCode.INVALID_COMMENT_NOT_BOOKMARK);
 		}
 		return bookCommentRepository.updateBookComment(bookId, userId, bookCommentUpdateRequest);
 	}

--- a/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
@@ -21,7 +21,6 @@ import com.dadok.gaerval.domain.book.repository.BookRepository;
 import com.dadok.gaerval.domain.bookshelf.repository.BookshelfItemRepository;
 import com.dadok.gaerval.global.config.externalapi.ExternalBookApiOperations;
 import com.dadok.gaerval.global.error.exception.ResourceNotfoundException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
<!--제목은 `[#이슈번호] 이슈 제목` 으로 작성한다.-->

### 🍀 목적
- custom exception에서 errorCode를 참조하지 못하는 이슈 해결
- `@Getter`와 명시적 getter code가 동시에 있어 리팩토링

### ☕ 변경사항<!-- 있다면 적고 없다면 적지 않는다.-->
- 상수 활용 -> 생성 시 enum 넘기기로 코드 변경 (프로젝트 컨벤션과 맞춤)

### ❓ pr 포인트


### 📢 Help


resolves #151<!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
