### PR TITLE
[#145] 좋아요 추가, 삭제 api 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -427,6 +427,42 @@ include::{snippets}/bookshelf-controller-slice-test/find-summary-bookshelf-by-us
 
 include::{snippets}/bookshelf-controller-slice-test/find-summary-bookshelf-by-user-id/response-fields.adoc[]
 
+=== 책장 좋아요 추가
+
+==== Request
+
+include::{snippets}/bookshelf-like-controller-slice-test/create-like/http-request.adoc[]
+
+==== Path Parameter
+
+include::{snippets}/bookshelf-like-controller-slice-test/create-like/path-parameters.adoc[]
+
+==== Request Header
+
+include::{snippets}/bookshelf-like-controller-slice-test/create-like/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/bookshelf-like-controller-test/create-like/http-response.adoc[]
+
+=== 책장 좋아요 취소
+
+==== Request
+
+include::{snippets}/bookshelf-like-controller-slice-test/delete-like/http-request.adoc[]
+
+==== Path Parameter
+
+include::{snippets}/bookshelf-like-controller-slice-test/delete-like/path-parameters.adoc[]
+
+==== Request Header
+
+include::{snippets}/bookshelf-like-controller-slice-test/delete-like/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/bookshelf-like-controller-test/delete-like/http-response.adoc[]
+
 == Book - 책
 
 === 책 검색
@@ -472,7 +508,6 @@ include::{snippets}/book-controller-slice-test/test-find-recent-query/http-respo
 ==== Response fields
 
 include::{snippets}/book-controller-slice-test/test-find-recent-query/response-fields.adoc[]
-
 
 === 책 상세 정보
 
@@ -888,13 +923,14 @@ include::{snippets}/book-group-comment-controller-slice-test/delete-book-group-c
 
 include::{snippets}/book-group-comment-controller-slice-test/delete-book-group-comment_-should-return-ok/path-parameters.adoc[]
 
-
 === 모임 검색
 
 ==== Request
+
 include::{snippets}/book-group-controller-slice-test/find-all-book-groups-by-query/http-request.adoc[]
 
 ==== Request Header
+
 include::{snippets}/book-group-controller-slice-test/find-all-book-groups-by-query/request-headers.adoc[]
 
 ==== Request Parameter

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
@@ -2,7 +2,7 @@ package com.dadok.gaerval.domain.bookshelf.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +17,7 @@ public class BookshelfLikeController {
 
 	private final BookshelfLikeService bookshelfLikeService;
 
-	@PutMapping
+	@PostMapping
 	public ResponseEntity<Void> createLike() {
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
@@ -1,0 +1,29 @@
+package com.dadok.gaerval.domain.bookshelf.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dadok.gaerval.domain.bookshelf.service.BookshelfLikeService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/bookshelf")
+@RestController
+@RequiredArgsConstructor
+public class BookshelfLikeController {
+
+	private final BookshelfLikeService bookshelfLikeService;
+
+	@PutMapping
+	public ResponseEntity<Void> createLike() {
+		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Void> deleteLike() {
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
@@ -14,7 +14,7 @@ import com.dadok.gaerval.global.config.security.UserPrincipal;
 
 import lombok.RequiredArgsConstructor;
 
-@RequestMapping("/api/bookshelf/{bookshelfId}/like")
+@RequestMapping("/api/bookshelves/{bookshelfId}/like")
 @RestController
 @RequiredArgsConstructor
 public class BookshelfLikeController {

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
@@ -1,29 +1,55 @@
 package com.dadok.gaerval.domain.bookshelf.api;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dadok.gaerval.domain.bookshelf.service.BookshelfLikeService;
+import com.dadok.gaerval.global.config.security.UserPrincipal;
 
 import lombok.RequiredArgsConstructor;
 
-@RequestMapping("/api/bookshelf")
+@RequestMapping("/api/bookshelf/{bookshelfId}/like")
 @RestController
 @RequiredArgsConstructor
 public class BookshelfLikeController {
 
 	private final BookshelfLikeService bookshelfLikeService;
 
-	@PostMapping
-	public ResponseEntity<Void> createLike() {
+	/***
+	 * <Pre>
+	 *     책장 좋아요 추가
+	 * </Pre>
+	 * @param bookshelfId
+	 * @param userPrincipal
+	 * @return
+	 */
+	@PostMapping()
+	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+	public ResponseEntity<Void> createLike(@PathVariable Long bookshelfId,
+		@AuthenticationPrincipal UserPrincipal userPrincipal) {
+		bookshelfLikeService.createBookshelfLike(userPrincipal.getUserId(), bookshelfId);
 		return ResponseEntity.ok().build();
 	}
 
-	@DeleteMapping
-	public ResponseEntity<Void> deleteLike() {
+	/***
+	 * <Pre>
+	 *     책장 좋아요 해제
+	 * </Pre>
+	 * @param bookshelfId
+	 * @param userPrincipal
+	 * @return
+	 */
+	@DeleteMapping()
+	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+	public ResponseEntity<Void> deleteLike(@PathVariable Long bookshelfId,
+		@AuthenticationPrincipal UserPrincipal userPrincipal) {
+		bookshelfLikeService.deleteBookshelfLike(userPrincipal.getUserId(), bookshelfId);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeController.java
@@ -27,7 +27,7 @@ public class BookshelfLikeController {
 	 * </Pre>
 	 * @param bookshelfId
 	 * @param userPrincipal
-	 * @return
+	 * @return status : ok
 	 */
 	@PostMapping()
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
@@ -43,7 +43,7 @@ public class BookshelfLikeController {
 	 * </Pre>
 	 * @param bookshelfId
 	 * @param userPrincipal
-	 * @return
+	 * @return status : ok
 	 */
 	@DeleteMapping()
 	@PreAuthorize(value = "hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/Bookshelf.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/Bookshelf.java
@@ -84,7 +84,7 @@ public class Bookshelf extends BaseTimeColumn {
 	}
 
 	public void addBookShelfLike(BookshelfLike bookshelfLike) {
-		CommonValidator.validateNotnull(bookshelfLike, "bookShelfItem");
+		CommonValidator.validateNotnull(bookshelfLike, "bookshelfLike");
 		bookshelfLikes.add(bookshelfLike);
 	}
 
@@ -95,12 +95,6 @@ public class Bookshelf extends BaseTimeColumn {
 
 	public void validateOwner(Long userId) {
 		if (!Objects.equals(userId, user.getId())) {
-			throw new BookshelfUserNotMatchedException();
-		}
-	}
-
-	public void validateNotOwner(Long userId) {
-		if (Objects.equals(userId, user.getId())) {
 			throw new BookshelfUserNotMatchedException();
 		}
 	}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/Bookshelf.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/Bookshelf.java
@@ -54,6 +54,10 @@ public class Bookshelf extends BaseTimeColumn {
 	@OneToMany(mappedBy = "bookshelf", cascade = CascadeType.ALL, orphanRemoval = true)
 	private final List<BookshelfItem> bookshelfItems = new ArrayList<>();
 
+	@JsonManagedReference
+	@OneToMany(mappedBy = "bookshelf", cascade = CascadeType.PERSIST, orphanRemoval = true)
+	private final List<BookshelfLike> bookshelfLikes = new ArrayList<>(); //set 덮어쓰기?
+
 	@Column(name = "job_id", nullable = true)
 	private Long jobId;
 
@@ -75,6 +79,11 @@ public class Bookshelf extends BaseTimeColumn {
 			throw new AlreadyContainBookshelfItemException();
 		}
 		bookshelfItems.add(bookshelfItem);
+	}
+
+	public void addBookShelfLike(BookshelfLike bookshelfLike) {
+		CommonValidator.validateNotnull(bookshelfLike, "bookShelfItem");
+		bookshelfLikes.add(bookshelfLike);
 	}
 
 	public void changeIsPublic(Boolean isPublic) {

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/Bookshelf.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/Bookshelf.java
@@ -1,8 +1,10 @@
 package com.dadok.gaerval.domain.bookshelf.entity;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -56,7 +58,7 @@ public class Bookshelf extends BaseTimeColumn {
 
 	@JsonManagedReference
 	@OneToMany(mappedBy = "bookshelf", cascade = CascadeType.PERSIST, orphanRemoval = true)
-	private final List<BookshelfLike> bookshelfLikes = new ArrayList<>(); //set 덮어쓰기?
+	private final Set<BookshelfLike> bookshelfLikes = new HashSet<>(); //set 덮어쓰기?
 
 	@Column(name = "job_id", nullable = true)
 	private Long jobId;
@@ -93,6 +95,12 @@ public class Bookshelf extends BaseTimeColumn {
 
 	public void validateOwner(Long userId) {
 		if (!Objects.equals(userId, user.getId())) {
+			throw new BookshelfUserNotMatchedException();
+		}
+	}
+
+	public void validateNotOwner(Long userId) {
+		if (Objects.equals(userId, user.getId())) {
 			throw new BookshelfUserNotMatchedException();
 		}
 	}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/Bookshelf.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/Bookshelf.java
@@ -58,7 +58,7 @@ public class Bookshelf extends BaseTimeColumn {
 
 	@JsonManagedReference
 	@OneToMany(mappedBy = "bookshelf", cascade = CascadeType.PERSIST, orphanRemoval = true)
-	private final Set<BookshelfLike> bookshelfLikes = new HashSet<>(); //set 덮어쓰기?
+	private final Set<BookshelfLike> bookshelfLikes = new HashSet<>();
 
 	@Column(name = "job_id", nullable = true)
 	private Long jobId;

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfItem.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfItem.java
@@ -27,7 +27,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "Bookshelf_items",
+@Table(name = "Bookshelf_item",
 	uniqueConstraints = {
 		@UniqueConstraint(name = "bookshelf_id_book_id_unique_key",
 			columnNames = {"bookshelf_id", "book_id"})

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfItem.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfItem.java
@@ -27,7 +27,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "Bookshelf_item",
+@Table(name = "Bookshelf_items",
 	uniqueConstraints = {
 		@UniqueConstraint(name = "bookshelf_id_book_id_unique_key",
 			columnNames = {"bookshelf_id", "book_id"})

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLike.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLike.java
@@ -1,0 +1,75 @@
+package com.dadok.gaerval.domain.bookshelf.entity;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import com.dadok.gaerval.domain.user.entity.User;
+import com.dadok.gaerval.global.common.JacocoExcludeGenerated;
+import com.dadok.gaerval.global.common.entity.BaseTimeColumn;
+
+import io.jsonwebtoken.lang.Assert;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "Bookshelf_likes",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "bookshelf_id_user_id_unique_key",
+			columnNames = {"bookshelf_id", "user_id"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookshelfLike extends BaseTimeColumn {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(nullable = false, name = "user_id")
+	private User user;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(nullable = false, name = "bookshelf_id")
+	private Bookshelf bookshelf;
+
+	private BookshelfLike(User user, Bookshelf bookshelf) {
+		Assert.notNull(bookshelf, "BookshelfLike의 bookshelf는 null일 수 없습니다.");
+		Assert.notNull(user, "BookshelfLike의 user은 null일 수 없습니다.");
+		this.user = user;
+		this.bookshelf = bookshelf;
+	}
+
+	public static BookshelfLike create(User user, Bookshelf bookshelf) {
+		return new BookshelfLike(user, bookshelf);
+	}
+
+	@Override
+	@JacocoExcludeGenerated
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		BookshelfLike that = (BookshelfLike)o;
+		return user.equals(that.user) && bookshelf.equals(that.bookshelf);
+	}
+
+	@Override
+	@JacocoExcludeGenerated
+	public int hashCode() {
+		return Objects.hash(user, bookshelf);
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLike.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLike.java
@@ -9,15 +9,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 import com.dadok.gaerval.domain.user.entity.User;
 import com.dadok.gaerval.global.common.JacocoExcludeGenerated;
 import com.dadok.gaerval.global.common.entity.BaseTimeColumn;
+import com.dadok.gaerval.global.util.CommonValidator;
 
-import io.jsonwebtoken.lang.Assert;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -41,15 +40,16 @@ public class BookshelfLike extends BaseTimeColumn {
 	@JoinColumn(nullable = false, name = "user_id")
 	private User user;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(nullable = false, name = "bookshelf_id")
 	private Bookshelf bookshelf;
 
 	private BookshelfLike(User user, Bookshelf bookshelf) {
-		Assert.notNull(bookshelf, "BookshelfLike의 bookshelf는 null일 수 없습니다.");
-		Assert.notNull(user, "BookshelfLike의 user은 null일 수 없습니다.");
+		CommonValidator.validateNotnull(bookshelf, "bookshelf");
+		CommonValidator.validateNotnull(user, "user");
 		this.user = user;
 		this.bookshelf = bookshelf;
+		bookshelf.addBookShelfLike(this);
 	}
 
 	public static BookshelfLike create(User user, Bookshelf bookshelf) {

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLike.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLike.java
@@ -12,6 +12,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
+import com.dadok.gaerval.domain.bookshelf.exception.BookshelfUserNotMatchedException;
 import com.dadok.gaerval.domain.user.entity.User;
 import com.dadok.gaerval.global.common.JacocoExcludeGenerated;
 import com.dadok.gaerval.global.common.entity.BaseTimeColumn;
@@ -47,6 +48,7 @@ public class BookshelfLike extends BaseTimeColumn {
 	private BookshelfLike(User user, Bookshelf bookshelf) {
 		CommonValidator.validateNotnull(bookshelf, "bookshelf");
 		CommonValidator.validateNotnull(user, "user");
+		validateNotOwner(user, bookshelf);
 		this.user = user;
 		this.bookshelf = bookshelf;
 		bookshelf.addBookShelfLike(this);
@@ -54,6 +56,12 @@ public class BookshelfLike extends BaseTimeColumn {
 
 	public static BookshelfLike create(User user, Bookshelf bookshelf) {
 		return new BookshelfLike(user, bookshelf);
+	}
+
+	private void validateNotOwner(User user, Bookshelf bookshelf) {
+		if (Objects.equals(bookshelf.getUser().getId(), user.getId())) {
+			throw new BookshelfUserNotMatchedException();
+		}
 	}
 
 	@Override

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLike.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLike.java
@@ -22,8 +22,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
-@Table(name = "Bookshelf_likes",
+@Entity(name = "bookshelf_likes")
+@Table(
 	uniqueConstraints = {
 		@UniqueConstraint(name = "bookshelf_id_user_id_unique_key",
 			columnNames = {"bookshelf_id", "user_id"})

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/exception/AlreadyExistsBookshelfLikeException.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/exception/AlreadyExistsBookshelfLikeException.java
@@ -2,7 +2,6 @@ package com.dadok.gaerval.domain.bookshelf.exception;
 
 import static com.dadok.gaerval.global.error.ErrorCode.*;
 
-import com.dadok.gaerval.global.error.ErrorCode;
 import com.dadok.gaerval.global.error.exception.BusinessException;
 
 public class AlreadyExistsBookshelfLikeException extends BusinessException {
@@ -11,13 +10,4 @@ public class AlreadyExistsBookshelfLikeException extends BusinessException {
 		super(ALREADY_EXISTS_BOOKSHELF_LIKE, String.format(ALREADY_EXISTS_BOOKSHELF_LIKE.getMessage(), bookshelfId));
 	}
 
-	@Override
-	public String getMessage() {
-		return super.getMessage();
-	}
-
-	@Override
-	public ErrorCode getErrorCode() {
-		return ALREADY_EXISTS_BOOKSHELF_LIKE;
-	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/exception/AlreadyExistsBookshelfLikeException.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/exception/AlreadyExistsBookshelfLikeException.java
@@ -1,0 +1,23 @@
+package com.dadok.gaerval.domain.bookshelf.exception;
+
+import static com.dadok.gaerval.global.error.ErrorCode.*;
+
+import com.dadok.gaerval.global.error.ErrorCode;
+import com.dadok.gaerval.global.error.exception.BusinessException;
+
+public class AlreadyExistsBookshelfLikeException extends BusinessException {
+
+	public AlreadyExistsBookshelfLikeException(Long bookshelfId) {
+		super(ALREADY_EXISTS_BOOKSHELF_LIKE, String.format(ALREADY_EXISTS_BOOKSHELF_LIKE.getMessage(), bookshelfId));
+	}
+
+	@Override
+	public String getMessage() {
+		return super.getMessage();
+	}
+
+	@Override
+	public ErrorCode getErrorCode() {
+		return ALREADY_EXISTS_BOOKSHELF_LIKE;
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepository.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.dadok.gaerval.domain.bookshelf.entity.BookshelfLike;
 
-public interface BookshelfLikeRepository extends JpaRepository<BookshelfLike, Long> {
+public interface BookshelfLikeRepository extends JpaRepository<BookshelfLike, Long>, BookshelfLikeSupport {
 
 	Optional<BookshelfLike> findByUserIdAndBookshelfId(Long userId, Long bookshelfId);
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepository.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepository.java
@@ -1,0 +1,12 @@
+package com.dadok.gaerval.domain.bookshelf.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dadok.gaerval.domain.bookshelf.entity.BookshelfLike;
+
+public interface BookshelfLikeRepository extends JpaRepository<BookshelfLike, Long> {
+
+	Optional<BookshelfLike> findByUserIdAndBookshelfId(Long userId, Long bookshelfId);
+}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupport.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupport.java
@@ -1,0 +1,5 @@
+package com.dadok.gaerval.domain.bookshelf.repository;
+
+public interface BookshelfLikeSupport {
+	boolean existsByBookshelfIdAndUserId(Long bookshelfId, Long userId);
+}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupport.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupport.java
@@ -2,5 +2,5 @@ package com.dadok.gaerval.domain.bookshelf.repository;
 
 public interface BookshelfLikeSupport {
 
-	boolean existsByBookshelfIdAndUserId(Long bookshelfId, Long userId);
+	boolean existsLike(Long bookshelfId, Long userId);
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupport.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupport.java
@@ -1,5 +1,6 @@
 package com.dadok.gaerval.domain.bookshelf.repository;
 
 public interface BookshelfLikeSupport {
+
 	boolean existsByBookshelfIdAndUserId(Long bookshelfId, Long userId);
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupportImpl.java
@@ -12,7 +12,7 @@ public class BookshelfLikeSupportImpl implements BookshelfLikeSupport {
 	private final JPAQueryFactory query;
 
 	@Override
-	public boolean existsByBookshelfIdAndUserId(Long bookshelfId, Long userId) {
+	public boolean existsLike(Long bookshelfId, Long userId) {
 		Integer fetchOne = query.selectOne().from(bookshelfLike)
 			.where(bookshelfLike.bookshelf.id.eq(bookshelfId), bookshelfLike.user.id.eq(userId))
 			.fetchFirst();

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeSupportImpl.java
@@ -1,0 +1,22 @@
+package com.dadok.gaerval.domain.bookshelf.repository;
+
+import static com.dadok.gaerval.domain.bookshelf.entity.QBookshelfLike.*;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BookshelfLikeSupportImpl implements BookshelfLikeSupport {
+
+	private final JPAQueryFactory query;
+
+	@Override
+	public boolean existsByBookshelfIdAndUserId(Long bookshelfId, Long userId) {
+		Integer fetchOne = query.selectOne().from(bookshelfLike)
+			.where(bookshelfLike.bookshelf.id.eq(bookshelfId), bookshelfLike.user.id.eq(userId))
+			.fetchFirst();
+
+		return fetchOne != null;
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/service/BookshelfLikeService.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/service/BookshelfLikeService.java
@@ -1,0 +1,8 @@
+package com.dadok.gaerval.domain.bookshelf.service;
+
+public interface BookshelfLikeService {
+
+	void createBookshelfLike(Long userId, Long bookshelfId);
+
+	void deleteBookshelfLike(Long userId, Long bookshelfId);
+}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeService.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeService.java
@@ -1,0 +1,42 @@
+package com.dadok.gaerval.domain.bookshelf.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dadok.gaerval.domain.bookshelf.entity.Bookshelf;
+import com.dadok.gaerval.domain.bookshelf.entity.BookshelfLike;
+import com.dadok.gaerval.domain.bookshelf.repository.BookshelfLikeRepository;
+import com.dadok.gaerval.domain.user.entity.User;
+import com.dadok.gaerval.domain.user.service.UserService;
+import com.dadok.gaerval.global.error.exception.ResourceNotfoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DefaultBookshelfLikeService implements BookshelfLikeService {
+
+	private final BookshelfLikeRepository bookshelfLikeRepository;
+
+	private final UserService userService;
+
+	private final BookshelfService bookshelfService;
+
+	@Override
+	public void createBookshelfLike(Long userId, Long bookshelfId) {
+		User user = userService.getById(userId);
+		Bookshelf bookshelf = bookshelfService.getById(bookshelfId);
+
+		BookshelfLike bookshelfLike = BookshelfLike.create(user, bookshelf);
+		bookshelfLikeRepository.save(bookshelfLike);
+	}
+
+	@Override
+	public void deleteBookshelfLike(Long userId, Long bookshelfId) {
+		BookshelfLike bookshelfLike = bookshelfLikeRepository.findByUserIdAndBookshelfId(userId, bookshelfId)
+			.orElseThrow(() -> new ResourceNotfoundException(BookshelfLike.class));
+
+		bookshelfLikeRepository.deleteById(bookshelfLike.getId());
+	}
+}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeService.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeService.java
@@ -28,7 +28,6 @@ public class DefaultBookshelfLikeService implements BookshelfLikeService {
 	public void createBookshelfLike(Long userId, Long bookshelfId) {
 		User user = userService.getById(userId);
 		Bookshelf bookshelf = bookshelfService.getById(bookshelfId);
-		bookshelf.validateNotOwner(userId);
 		if (bookshelfLikeRepository.existsByBookshelfIdAndUserId(bookshelfId, userId)) {
 			throw new AlreadyExistsBookshelfLikeException(bookshelf.getId());
 		}

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeService.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.dadok.gaerval.domain.bookshelf.entity.Bookshelf;
 import com.dadok.gaerval.domain.bookshelf.entity.BookshelfLike;
+import com.dadok.gaerval.domain.bookshelf.exception.AlreadyExistsBookshelfLikeException;
 import com.dadok.gaerval.domain.bookshelf.repository.BookshelfLikeRepository;
 import com.dadok.gaerval.domain.user.entity.User;
 import com.dadok.gaerval.domain.user.service.UserService;
@@ -27,16 +28,17 @@ public class DefaultBookshelfLikeService implements BookshelfLikeService {
 	public void createBookshelfLike(Long userId, Long bookshelfId) {
 		User user = userService.getById(userId);
 		Bookshelf bookshelf = bookshelfService.getById(bookshelfId);
-
-		BookshelfLike bookshelfLike = BookshelfLike.create(user, bookshelf);
-		bookshelfLikeRepository.save(bookshelfLike);
+		bookshelf.validateNotOwner(userId);
+		if (bookshelfLikeRepository.existsByBookshelfIdAndUserId(bookshelfId, userId)) {
+			throw new AlreadyExistsBookshelfLikeException(bookshelf.getId());
+		}
+		bookshelfLikeRepository.save(BookshelfLike.create(user, bookshelf));
 	}
 
 	@Override
 	public void deleteBookshelfLike(Long userId, Long bookshelfId) {
 		BookshelfLike bookshelfLike = bookshelfLikeRepository.findByUserIdAndBookshelfId(userId, bookshelfId)
 			.orElseThrow(() -> new ResourceNotfoundException(BookshelfLike.class));
-
 		bookshelfLikeRepository.deleteById(bookshelfLike.getId());
 	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeService.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeService.java
@@ -28,7 +28,7 @@ public class DefaultBookshelfLikeService implements BookshelfLikeService {
 	public void createBookshelfLike(Long userId, Long bookshelfId) {
 		User user = userService.getById(userId);
 		Bookshelf bookshelf = bookshelfService.getById(bookshelfId);
-		if (bookshelfLikeRepository.existsByBookshelfIdAndUserId(bookshelfId, userId)) {
+		if (bookshelfLikeRepository.existsLike(bookshelfId, userId)) {
 			throw new AlreadyExistsBookshelfLikeException(bookshelf.getId());
 		}
 		bookshelfLikeRepository.save(BookshelfLike.create(user, bookshelf));

--- a/src/main/java/com/dadok/gaerval/global/error/ErrorCode.java
+++ b/src/main/java/com/dadok/gaerval/global/error/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
 	ALREADY_CONTAIN_BOOKSHELF_ITEM(HttpStatus.BAD_REQUEST, "BS1", "이미 책장에 포함된 아아템입니다."),
 	BOOKSHELF_USER_NOT_MATCHED(HttpStatus.UNAUTHORIZED, "BS2", "해당 책장에 올바르지 않은 사용자 접근입니다."),
 
+	ALREADY_EXISTS_BOOKSHELF_LIKE(HttpStatus.BAD_REQUEST, "BSL1", "해당 책장에 대한 좋아요가 이미 존재합니다. 책장 id : %s"),
+
 	// Book
 	BOOK_DATA_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "B1", "잘못된 도서 데이터 형식입니다."),
 	BOOK_API_NOT_AVAILABLE(HttpStatus.INTERNAL_SERVER_ERROR, "B2", "도서 API를 호출할 수 없습니다."),
@@ -72,8 +74,6 @@ public enum ErrorCode {
 		"유효하지 않은 앱키나 액세스 토큰으로 요청한 경우, 등록된 앱 정보와 호출된 앱 정보가 불일치 하는 경우(해결 방법: 앱키 확인 또는 토큰 갱신, 개발자 사이트에 등록된 앱 정보 확인)"),
 	KAKAO_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "603", "카카오 플랫폼 내부에서 요청 처리 중 타임아웃이 발생한 경우"),
 	KAKAO_SERVICE_CHECK(HttpStatus.SERVICE_UNAVAILABLE, "9798", "서비스 점검중");
-
-
 
 	private final HttpStatus status;
 

--- a/src/main/java/com/dadok/gaerval/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dadok/gaerval/global/error/handler/GlobalExceptionHandler.java
@@ -42,6 +42,7 @@ import com.dadok.gaerval.domain.book_group.exception.ExceedLimitMemberException;
 import com.dadok.gaerval.domain.book_group.exception.ExpiredJoinGroupPeriodException;
 import com.dadok.gaerval.domain.book_group.exception.NotMatchedPasswordException;
 import com.dadok.gaerval.domain.bookshelf.exception.AlreadyContainBookshelfItemException;
+import com.dadok.gaerval.domain.bookshelf.exception.AlreadyExistsBookshelfLikeException;
 import com.dadok.gaerval.domain.bookshelf.exception.BookshelfUserNotMatchedException;
 import com.dadok.gaerval.global.config.security.exception.JwtAuthenticationException;
 import com.dadok.gaerval.global.error.ErrorCode;
@@ -382,10 +383,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return of(errorCode, request.getRequestURI());
 	}
 
-
 	@ExceptionHandler(NotMarkedBookException.class)
 	public ResponseEntity<ErrorResponse> handleBookNotMarkedException(
 		HttpServletRequest request, NotMarkedBookException e) {
+
+		ErrorCode errorCode = e.getErrorCode();
+		logInfo(e, request.getRequestURI());
+
+		return of(errorCode, request.getRequestURI());
+	}
+
+	@ExceptionHandler(AlreadyExistsBookshelfLikeException.class)
+	public ResponseEntity<ErrorResponse> handleAlreadyExistBookshelfLikeException(
+		HttpServletRequest request, AlreadyExistsBookshelfLikeException e) {
 
 		ErrorCode errorCode = e.getErrorCode();
 		logInfo(e, request.getRequestURI());

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -2,6 +2,8 @@ drop table if exists book_comments cascade;
 
 drop table if exists bookshelf_item cascade;
 
+drop table if exists bookshelf_likes cascade;
+
 drop table if exists bookshelves cascade;
 
 drop table if exists group_comments cascade;
@@ -173,6 +175,19 @@ create table if not exists  bookshelf_item
     constraint FKmxi0cndspoavkel5ei7i3l4pm
         foreign key (book_id) references books (id)
 );
+
+create table if not exists  bookshelf_likes
+(
+    id           bigint auto_increment
+    primary key,
+    created_at   datetime(6) not null,
+    modified_at  datetime(6) null,
+    user_id      bigint      not null,
+    bookshelf_id bigint      not null,
+    foreign key (bookshelf_id) references bookshelves (id),
+    foreign key (user_id) references users (id),
+    unique (user_id, bookshelf_id)
+    );
 
 create index job_id_index
     on bookshelves (job_id);

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeControllerTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/api/BookshelfLikeControllerTest.java
@@ -1,0 +1,96 @@
+package com.dadok.gaerval.domain.bookshelf.api;
+
+import static com.dadok.gaerval.global.config.security.jwt.AuthService.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import com.dadok.gaerval.controller.ControllerSliceTest;
+import com.dadok.gaerval.domain.bookshelf.service.BookshelfLikeService;
+import com.dadok.gaerval.testutil.WithMockCustomOAuth2LoginUser;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceDocumentation;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+
+@WebMvcTest(controllers = BookshelfLikeController.class)
+@WithMockCustomOAuth2LoginUser
+class BookshelfLikeControllerSliceTest extends ControllerSliceTest {
+
+	@MockBean
+	private BookshelfLikeService bookshelfLikeService;
+
+	@DisplayName("createLike - 책장 좋아요 생성")
+	@Test
+	void createLike() throws Exception {
+		// Given
+		doNothing().when(bookshelfLikeService).createBookshelfLike(any(), eq(2L));
+
+		// When // Then
+		mockMvc.perform(post("/api/bookshelves/{bookshelvesId}/like", 2L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(ACCESS_TOKEN_HEADER_NAME, MOCK_ACCESS_TOKEN)
+				.characterEncoding(StandardCharsets.UTF_8)
+			).andExpect(status().isOk())
+			.andDo(print())
+			.andDo(this.restDocs.document(
+				requestHeaders(
+					headerWithName(ACCESS_TOKEN_HEADER_NAME).description(ACCESS_TOKEN_HEADER_NAME_DESCRIPTION)
+				),
+				pathParameters(
+					parameterWithName("bookshelvesId").description("첵장 Id")
+				)
+			))
+			.andDo(MockMvcRestDocumentationWrapper.document("{class-name}/{method-name}",
+				ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+					.requestHeaders(
+						headerWithName(ACCESS_TOKEN_HEADER_NAME).description(ACCESS_TOKEN_HEADER_NAME_DESCRIPTION))
+					.pathParameters(
+						parameterWithName("bookshelvesId").description("첵장 Id")
+					)
+					.build()
+				)));
+	}
+
+	@DisplayName("deleteLike - 책장 좋아요 삭제")
+	@Test
+	void deleteLike() throws Exception {
+		// Given
+		doNothing().when(bookshelfLikeService).deleteBookshelfLike(any(), eq(2L));
+
+		// When // Then
+		mockMvc.perform(delete("/api/bookshelves/{bookshelvesId}/like", 2L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.header(ACCESS_TOKEN_HEADER_NAME, MOCK_ACCESS_TOKEN)
+				.characterEncoding(StandardCharsets.UTF_8)
+			).andExpect(status().isOk())
+			.andDo(print())
+			.andDo(this.restDocs.document(
+				requestHeaders(
+					headerWithName(ACCESS_TOKEN_HEADER_NAME).description(ACCESS_TOKEN_HEADER_NAME_DESCRIPTION)
+				),
+				pathParameters(
+					parameterWithName("bookshelvesId").description("첵장 Id")
+				)
+			))
+			.andDo(MockMvcRestDocumentationWrapper.document("{class-name}/{method-name}",
+				ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+					.requestHeaders(
+						headerWithName(ACCESS_TOKEN_HEADER_NAME).description(ACCESS_TOKEN_HEADER_NAME_DESCRIPTION))
+					.pathParameters(
+						parameterWithName("bookshelvesId").description("첵장 Id")
+					)
+					.build()
+				)));
+	}
+}

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLikeTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLikeTest.java
@@ -1,10 +1,15 @@
 package com.dadok.gaerval.domain.bookshelf.entity;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.dadok.gaerval.domain.bookshelf.exception.BookshelfUserNotMatchedException;
 import com.dadok.gaerval.domain.user.entity.User;
+import com.dadok.gaerval.global.error.exception.InvalidArgumentException;
 import com.dadok.gaerval.testutil.JobObjectProvider;
 import com.dadok.gaerval.testutil.UserObjectProvider;
 
@@ -16,16 +21,42 @@ class BookshelfLikeTest {
 
 	private final Bookshelf bookshelf = Bookshelf.create(owner);
 
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(owner, "id", 1L);
+		ReflectionTestUtils.setField(user, "id", 2L);
+	}
+
 	@Test
-	@DisplayName("create")
-	void test() {
-		BookshelfLike bookshelfLike = BookshelfLike.create(user, bookshelf);
-		ReflectionTestUtils.setField(bookshelfLike, "id", 5L);
+	@DisplayName("create - 모든 필드가 유효 - 성공")
+	void create_success() {
+		assertDoesNotThrow(() -> {
+			BookshelfLike.create(user, bookshelf);
+		});
+	}
 
-		BookshelfLike bookshelfLike2 = BookshelfLike.create(user, bookshelf);
-		ReflectionTestUtils.setField(bookshelfLike2, "id", 6L);
+	@Test
+	@DisplayName("create - 책장이 null일 경우 - 실패")
+	void create_bookshelfNull_fail() {
+		assertThrows(InvalidArgumentException.class, () -> {
+			BookshelfLike.create(user, null);
+		});
+	}
 
-		System.out.println(bookshelf.getBookshelfLikes());
+	@Test
+	@DisplayName("create - 사용자가 null일 경우 - 실패")
+	void create_userNull_fail() {
+		assertThrows(InvalidArgumentException.class, () -> {
+			BookshelfLike.create(null, bookshelf);
+		});
+	}
+
+	@Test
+	@DisplayName("create - 자신의 책장일경우 - 실패")
+	void create_BookshelfOwner_fail() {
+		assertThrows(BookshelfUserNotMatchedException.class, () -> {
+			BookshelfLike.create(owner, bookshelf);
+		});
 	}
 
 }

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLikeTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/entity/BookshelfLikeTest.java
@@ -1,0 +1,31 @@
+package com.dadok.gaerval.domain.bookshelf.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.dadok.gaerval.domain.user.entity.User;
+import com.dadok.gaerval.testutil.JobObjectProvider;
+import com.dadok.gaerval.testutil.UserObjectProvider;
+
+class BookshelfLikeTest {
+
+	private final User owner = UserObjectProvider.createKakaoUser(JobObjectProvider.backendJob());
+
+	private final User user = UserObjectProvider.createNaverUser();
+
+	private final Bookshelf bookshelf = Bookshelf.create(owner);
+
+	@Test
+	@DisplayName("create")
+	void test() {
+		BookshelfLike bookshelfLike = BookshelfLike.create(user, bookshelf);
+		ReflectionTestUtils.setField(bookshelfLike, "id", 5L);
+
+		BookshelfLike bookshelfLike2 = BookshelfLike.create(user, bookshelf);
+		ReflectionTestUtils.setField(bookshelfLike2, "id", 6L);
+
+		System.out.println(bookshelf.getBookshelfLikes());
+	}
+
+}

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepositoryTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestConstructor;
 
 import com.dadok.gaerval.domain.bookshelf.entity.Bookshelf;
+import com.dadok.gaerval.domain.bookshelf.entity.BookshelfLike;
 import com.dadok.gaerval.domain.job.repository.JobRepository;
 import com.dadok.gaerval.domain.user.entity.Authority;
 import com.dadok.gaerval.domain.user.entity.Role;
@@ -42,6 +43,8 @@ class BookshelfLikeRepositoryTest {
 
 	private Bookshelf bookshelf;
 
+	private BookshelfLike bookshelfLike;
+
 	@BeforeEach
 	void setUp() {
 		authority = authorityRepository.save(Authority.create(Role.USER));
@@ -53,12 +56,25 @@ class BookshelfLikeRepositoryTest {
 
 		user.changeJob(job);
 		bookshelf = bookshelfRepository.save(Bookshelf.create(user));
+		bookshelfLike = BookshelfLike.create(user, bookshelf);
+		bookshelfLikeRepository.save(bookshelfLike);
 	}
 
 	@Test
 	@DisplayName("조회 - 책장과 사용자을 입력받아 entity 조회")
 	void findByUserIdAndBookshelfId() {
 		bookshelfLikeRepository.findByUserIdAndBookshelfId(user.getId(), bookshelf.getId());
+	}
+
+	@Test
+	void save() {
+		BookshelfLike newBookshelfLike = BookshelfLike.create(user, bookshelf);
+
+		System.out.println(bookshelfLike);
+		bookshelfLikeRepository.save(newBookshelfLike);
+
+		System.out.println(bookshelfLike);
+
 	}
 
 }

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepositoryTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepositoryTest.java
@@ -25,7 +25,6 @@ class BookshelfLikeRepositoryTest {
 	@Test
 	@DisplayName("책장과 사용자를 입력받아 존재 여부 확인")
 	void existsByBookshelfIdAndUserId() {
-		bookshelfLikeRepository.existsByBookshelfIdAndUserId(2L, 4L);
+		bookshelfLikeRepository.existsLike(2L, 4L);
 	}
-
 }

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepositoryTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepositoryTest.java
@@ -1,23 +1,10 @@
 package com.dadok.gaerval.domain.bookshelf.repository;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestConstructor;
 
-import com.dadok.gaerval.domain.bookshelf.entity.Bookshelf;
-import com.dadok.gaerval.domain.bookshelf.entity.BookshelfLike;
-import com.dadok.gaerval.domain.job.repository.JobRepository;
-import com.dadok.gaerval.domain.user.entity.Authority;
-import com.dadok.gaerval.domain.user.entity.Role;
-import com.dadok.gaerval.domain.user.entity.User;
-import com.dadok.gaerval.domain.user.entity.UserAuthority;
-import com.dadok.gaerval.domain.user.repository.AuthorityRepository;
-import com.dadok.gaerval.domain.user.repository.UserRepository;
-import com.dadok.gaerval.global.oauth.OAuth2Attribute;
 import com.dadok.gaerval.repository.CustomDataJpaTest;
-import com.dadok.gaerval.testutil.JobObjectProvider;
-import com.dadok.gaerval.testutil.UserObjectProvider;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,52 +16,16 @@ class BookshelfLikeRepositoryTest {
 
 	private final BookshelfLikeRepository bookshelfLikeRepository;
 
-	private final BookshelfRepository bookshelfRepository;
-
-	private final JobRepository jobRepository;
-
-	private final AuthorityRepository authorityRepository;
-
-	private final UserRepository userRepository;
-
-	private Authority authority;
-
-	private User user;
-
-	private Bookshelf bookshelf;
-
-	private BookshelfLike bookshelfLike;
-
-	@BeforeEach
-	void setUp() {
-		authority = authorityRepository.save(Authority.create(Role.USER));
-		var job = jobRepository.save(JobObjectProvider.backendJob());
-		Authority authority = authorityRepository.getReferenceById(Role.USER);
-		OAuth2Attribute oAuth2Attribute = UserObjectProvider.kakaoAttribute();
-		user = User.createByOAuth(oAuth2Attribute, UserAuthority.create(authority));
-		userRepository.saveAndFlush(user);
-
-		user.changeJob(job);
-		bookshelf = bookshelfRepository.save(Bookshelf.create(user));
-		bookshelfLike = BookshelfLike.create(user, bookshelf);
-		bookshelfLikeRepository.save(bookshelfLike);
-	}
-
 	@Test
 	@DisplayName("조회 - 책장과 사용자을 입력받아 entity 조회")
 	void findByUserIdAndBookshelfId() {
-		bookshelfLikeRepository.findByUserIdAndBookshelfId(user.getId(), bookshelf.getId());
+		bookshelfLikeRepository.findByUserIdAndBookshelfId(2L, 4L);
 	}
 
 	@Test
-	void save() {
-		BookshelfLike newBookshelfLike = BookshelfLike.create(user, bookshelf);
-
-		System.out.println(bookshelfLike);
-		bookshelfLikeRepository.save(newBookshelfLike);
-
-		System.out.println(bookshelfLike);
-
+	@DisplayName("책장과 사용자를 입력받아 존재 여부 확인")
+	void existsByBookshelfIdAndUserId() {
+		bookshelfLikeRepository.existsByBookshelfIdAndUserId(2L, 4L);
 	}
 
 }

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepositoryTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfLikeRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.dadok.gaerval.domain.bookshelf.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestConstructor;
+
+import com.dadok.gaerval.domain.bookshelf.entity.Bookshelf;
+import com.dadok.gaerval.domain.job.repository.JobRepository;
+import com.dadok.gaerval.domain.user.entity.Authority;
+import com.dadok.gaerval.domain.user.entity.Role;
+import com.dadok.gaerval.domain.user.entity.User;
+import com.dadok.gaerval.domain.user.entity.UserAuthority;
+import com.dadok.gaerval.domain.user.repository.AuthorityRepository;
+import com.dadok.gaerval.domain.user.repository.UserRepository;
+import com.dadok.gaerval.global.oauth.OAuth2Attribute;
+import com.dadok.gaerval.repository.CustomDataJpaTest;
+import com.dadok.gaerval.testutil.JobObjectProvider;
+import com.dadok.gaerval.testutil.UserObjectProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@DisplayName("bookshelfLike repository 쿼리 테스트")
+@CustomDataJpaTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+class BookshelfLikeRepositoryTest {
+
+	private final BookshelfLikeRepository bookshelfLikeRepository;
+
+	private final BookshelfRepository bookshelfRepository;
+
+	private final JobRepository jobRepository;
+
+	private final AuthorityRepository authorityRepository;
+
+	private final UserRepository userRepository;
+
+	private Authority authority;
+
+	private User user;
+
+	private Bookshelf bookshelf;
+
+	@BeforeEach
+	void setUp() {
+		authority = authorityRepository.save(Authority.create(Role.USER));
+		var job = jobRepository.save(JobObjectProvider.backendJob());
+		Authority authority = authorityRepository.getReferenceById(Role.USER);
+		OAuth2Attribute oAuth2Attribute = UserObjectProvider.kakaoAttribute();
+		user = User.createByOAuth(oAuth2Attribute, UserAuthority.create(authority));
+		userRepository.saveAndFlush(user);
+
+		user.changeJob(job);
+		bookshelf = bookshelfRepository.save(Bookshelf.create(user));
+	}
+
+	@Test
+	@DisplayName("조회 - 책장과 사용자을 입력받아 entity 조회")
+	void findByUserIdAndBookshelfId() {
+		bookshelfLikeRepository.findByUserIdAndBookshelfId(user.getId(), bookshelf.getId());
+	}
+
+}

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeServiceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeServiceTest.java
@@ -1,5 +1,108 @@
 package com.dadok.gaerval.domain.bookshelf.service;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.dadok.gaerval.domain.bookshelf.entity.Bookshelf;
+import com.dadok.gaerval.domain.bookshelf.entity.BookshelfLike;
+import com.dadok.gaerval.domain.bookshelf.exception.AlreadyExistsBookshelfLikeException;
+import com.dadok.gaerval.domain.bookshelf.repository.BookshelfLikeRepository;
+import com.dadok.gaerval.domain.user.entity.User;
+import com.dadok.gaerval.domain.user.service.UserService;
+import com.dadok.gaerval.global.error.exception.ResourceNotfoundException;
+import com.dadok.gaerval.testutil.JobObjectProvider;
+import com.dadok.gaerval.testutil.UserObjectProvider;
+
+@ExtendWith(MockitoExtension.class)
 class DefaultBookshelfLikeServiceTest {
+
+	@InjectMocks
+	private DefaultBookshelfLikeService bookshelfLikeService;
+
+	@Mock
+	private BookshelfLikeRepository bookshelfLikeRepository;
+
+	@Mock
+	private BookshelfService bookshelfService;
+
+	@Mock
+	private UserService userService;
+
+	private final User user = UserObjectProvider.createKakaoUser(JobObjectProvider.backendJob());
+	private final Bookshelf bookshelf = Bookshelf.create(UserObjectProvider.createNaverUser());
+
+	@Test
+	void createBookshelfLike_success() {
+		// Given
+		ReflectionTestUtils.setField(user, "id", 1L);
+		given(userService.getById(1L))
+			.willReturn(user);
+		given(bookshelfService.getById(2L))
+			.willReturn(bookshelf);
+		given(bookshelfLikeRepository.existsByBookshelfIdAndUserId(2L, 1L))
+			.willReturn(Boolean.FALSE);
+
+		// When
+		assertDoesNotThrow(() -> {
+			bookshelfLikeService.createBookshelfLike(1L, 2L);
+		});
+
+		// Then
+		assertThat(bookshelf.getBookshelfLikes().size()).isEqualTo(1);
+	}
+
+	@Test
+	void createBookshelfLike_alreadyExist_fail() {
+		// Given
+		ReflectionTestUtils.setField(user, "id", 1L);
+		given(userService.getById(1L))
+			.willReturn(user);
+		given(bookshelfService.getById(2L))
+			.willReturn(bookshelf);
+		given(bookshelfLikeRepository.existsByBookshelfIdAndUserId(2L, 1L))
+			.willReturn(Boolean.TRUE);
+
+		// When // Then
+		assertThrows(AlreadyExistsBookshelfLikeException.class, () -> {
+			bookshelfLikeService.createBookshelfLike(1L, 2L);
+		});
+	}
+
+	@Test
+	void deleteBookshelfLike_success() {
+		// Given
+		ReflectionTestUtils.setField(user, "id", 1L);
+		BookshelfLike bookshelfLike = BookshelfLike.create(user, bookshelf);
+
+		given(bookshelfLikeRepository.findByUserIdAndBookshelfId(1L, 2L))
+			.willReturn(Optional.of(bookshelfLike));
+
+		// When // Then
+		assertDoesNotThrow(() -> {
+			bookshelfLikeService.deleteBookshelfLike(1L, 2L);
+		});
+	}
+
+	@Test
+	void deleteBookshelfLike_notExist_fail() {
+		// Given
+		given(bookshelfLikeRepository.findByUserIdAndBookshelfId(1L, 2L))
+			.willReturn(Optional.empty());
+
+		// When // Then
+		assertThrows(ResourceNotfoundException.class, () -> {
+			bookshelfLikeService.deleteBookshelfLike(1L, 2L);
+		});
+	}
 
 }

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeServiceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeServiceTest.java
@@ -49,7 +49,7 @@ class DefaultBookshelfLikeServiceTest {
 			.willReturn(user);
 		given(bookshelfService.getById(2L))
 			.willReturn(bookshelf);
-		given(bookshelfLikeRepository.existsByBookshelfIdAndUserId(2L, 1L))
+		given(bookshelfLikeRepository.existsLike(2L, 1L))
 			.willReturn(Boolean.FALSE);
 
 		// When
@@ -69,7 +69,7 @@ class DefaultBookshelfLikeServiceTest {
 			.willReturn(user);
 		given(bookshelfService.getById(2L))
 			.willReturn(bookshelf);
-		given(bookshelfLikeRepository.existsByBookshelfIdAndUserId(2L, 1L))
+		given(bookshelfLikeRepository.existsLike(2L, 1L))
 			.willReturn(Boolean.TRUE);
 
 		// When // Then

--- a/src/test/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeServiceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/bookshelf/service/DefaultBookshelfLikeServiceTest.java
@@ -1,0 +1,5 @@
+package com.dadok.gaerval.domain.bookshelf.service;
+
+class DefaultBookshelfLikeServiceTest {
+
+}


### PR DESCRIPTION
<!--제목은 `[#이슈번호] 이슈 제목` 으로 작성한다.-->

### 🍀 목적
좋아요 추가, 삭제 api 구현

### ❓ pr 포인트
- 자신의 책장은 좋아요 하지 못하게 하였습니다.
- 이미 좋아요가 있는데 중복으로 좋아요 생성 요청시 예외가 발생하도록 하였는데 이미 존재할 경우 존재하던 것을 삭제하고 새로 저장을 해도 괜찮을 것 같아요(인스타 좋아요 처럼) 
- 일단 slice test만 진행된 상태여서 추가 api 구현시 통합테스트도 추가하겠습니다.


#145 
<!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
