### PR TITLE
[#169] feat : 도서 검색 시 최근 키워드 저장 여부를 선택할 수 있도록 변경

### DIFF
--- a/src/main/java/com/dadok/gaerval/domain/book/dto/request/BookSearchRequest.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/dto/request/BookSearchRequest.java
@@ -10,11 +10,13 @@ public record BookSearchRequest(
 	@Range(min = 1, max = 50, message = "pageSize는 1에서 50사이 값입니다.")
 	Integer pageSize,
 	@NotBlank(message = "검색어는 빈 값일 수 없습니다.")
-	String query
+ 	String query,
+	Boolean isStoreRecent
 ) {
-	public BookSearchRequest(Integer page, Integer pageSize, String query) {
+	public BookSearchRequest(Integer page, Integer pageSize, String query, Boolean isStoreRecent) {
 		this.page = (page == null) ? 1 : page;
 		this.pageSize = (pageSize == null) ? 10 : pageSize;
 		this.query = query;
+		this.isStoreRecent = isStoreRecent != null && isStoreRecent;
 	}
 }

--- a/src/main/java/com/dadok/gaerval/domain/book/dto/response/BookRecentSearchResponse.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/dto/response/BookRecentSearchResponse.java
@@ -7,6 +7,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 public record BookRecentSearchResponse(
 	String keyword,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-	LocalDateTime createdAt
+	LocalDateTime modifiedAt
 ) {
 }

--- a/src/main/java/com/dadok/gaerval/domain/book/repository/BookRecentSearchSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/repository/BookRecentSearchSupportImpl.java
@@ -24,13 +24,13 @@ public class BookRecentSearchSupportImpl implements BookRecentSearchSupport {
 		List<BookRecentSearchResponse> bookRecentSearchResponseList = query.select(
 				Projections.constructor(BookRecentSearchResponse.class,
 					bookRecentSearch.keyword.as("keyword"),
-					bookRecentSearch.modifiedAt.as("modifiedAt")
+					bookRecentSearch.modifiedAt.coalesce(bookRecentSearch.createdAt).as("modifiedAt")
 				)
 			)
 			.from(bookRecentSearch)
 			.innerJoin(user).on(user.id.eq(bookRecentSearch.user.id))
 			.where(bookRecentSearch.user.id.eq(userId))
-			.orderBy(bookRecentSearch.modifiedAt.desc())
+			.orderBy(bookRecentSearch.modifiedAt.coalesce(bookRecentSearch.createdAt).desc())
 			.limit(limit)
 			.fetch();
 

--- a/src/main/java/com/dadok/gaerval/domain/book/repository/BookRecentSearchSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/repository/BookRecentSearchSupportImpl.java
@@ -24,13 +24,13 @@ public class BookRecentSearchSupportImpl implements BookRecentSearchSupport {
 		List<BookRecentSearchResponse> bookRecentSearchResponseList = query.select(
 				Projections.constructor(BookRecentSearchResponse.class,
 					bookRecentSearch.keyword.as("keyword"),
-					bookRecentSearch.createdAt.as("createdAt")
+					bookRecentSearch.modifiedAt.as("modifiedAt")
 				)
 			)
 			.from(bookRecentSearch)
 			.innerJoin(user).on(user.id.eq(bookRecentSearch.user.id))
 			.where(bookRecentSearch.user.id.eq(userId))
-			.orderBy(bookRecentSearch.createdAt.desc())
+			.orderBy(bookRecentSearch.modifiedAt.desc())
 			.limit(limit)
 			.fetch();
 

--- a/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
+++ b/src/main/java/com/dadok/gaerval/domain/book/service/DefaultBookService.java
@@ -60,7 +60,9 @@ public class DefaultBookService implements BookService {
 			bookSearchRequest.page(),
 			bookSearchRequest.pageSize(), SortingPolicy.ACCURACY.getName());
 
-		eventPublisher.publishEvent(new SaveKeywordEvent(userId, bookSearchRequest.query()));
+		if(Boolean.TRUE.equals(bookSearchRequest.isStoreRecent())) {
+			eventPublisher.publishEvent(new SaveKeywordEvent(userId, bookSearchRequest.query()));
+		}
 
 		return bookResponses;
 	}

--- a/src/test/java/com/dadok/gaerval/domain/book/api/BookControllerSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/api/BookControllerSliceTest.java
@@ -290,14 +290,14 @@ class BookControllerSliceTest extends ControllerSliceTest {
 					fieldWithPath("count").type(JsonFieldType.NUMBER)
 						.description("검색어 목록 개수"),
 					fieldWithPath("isEmpty").type(JsonFieldType.BOOLEAN)
-						.description("검색어 목록이 비어있는지 여부"),
+						.description("검색어 목록이 비어 있는지 여부"),
 					fieldWithPath("bookRecentSearchResponses").type(JsonFieldType.ARRAY)
 						.optional()
 						.description("최근 검색어 목록"),
 					fieldWithPath("bookRecentSearchResponses[].keyword").type(JsonFieldType.STRING)
 						.optional()
 						.description("검색어"),
-					fieldWithPath("bookRecentSearchResponses[].createdAt").type(JsonFieldType.STRING)
+					fieldWithPath("bookRecentSearchResponses[].modifiedAt").type(JsonFieldType.STRING)
 						.optional()
 						.description("검색시각 (yyyy-MM-dd HH:mm:ss)")
 				)

--- a/src/test/java/com/dadok/gaerval/domain/book/api/BookControllerSliceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/api/BookControllerSliceTest.java
@@ -66,7 +66,7 @@ class BookControllerSliceTest extends ControllerSliceTest {
 	void findBook_success() throws Exception {
 		// given
 		String keyword = "용기";
-		BookSearchRequest bookSearchRequest = new BookSearchRequest(1, 10, keyword);
+		BookSearchRequest bookSearchRequest = new BookSearchRequest(1, 10, keyword, true);
 		given(bookService.findAllByKeyword(bookSearchRequest, 1L)).willReturn(
 			BookObjectProvider.mockBookData());
 
@@ -75,6 +75,7 @@ class BookControllerSliceTest extends ControllerSliceTest {
 		params.add("page", bookSearchRequest.page().toString());
 		params.add("pageSize", bookSearchRequest.pageSize().toString());
 		params.add("query", bookSearchRequest.query());
+		params.add("isStoreRecent", String.valueOf(bookSearchRequest.isStoreRecent()));
 
 		// when
 		mockMvc.perform(get("/api/books")
@@ -102,6 +103,10 @@ class BookControllerSliceTest extends ControllerSliceTest {
 					parameterWithName("query").description("검색어")
 						.attributes(
 							constrainsAttribute(BookSearchRequest.class, "query")
+						),
+					parameterWithName("isStoreRecent").description("최근 검색어 저장 여부")
+						.attributes(
+							constrainsAttribute(BookSearchRequest.class, "isStoreRecent")
 						)
 				),
 				responseFields(

--- a/src/test/java/com/dadok/gaerval/domain/book/repository/BookRecentSearchSupportImplTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/repository/BookRecentSearchSupportImplTest.java
@@ -1,6 +1,7 @@
 package com.dadok.gaerval.domain.book.repository;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -47,5 +48,18 @@ class BookRecentSearchSupportImplTest {
 
 		// Then
 		assertTrue(user.isPresent());
+	}
+
+	@Test
+	@DisplayName("existsByKeywordAndUserId - 유저 id와 키워드로 검색어 존재 여부 확인 테스트")
+	void existsByKeywordAndUserIdTest() {
+		// Given
+		String keyword = "TestKeyword";
+		Long userId = 10L;
+
+		bookRecentSearchRepository.existsByKeywordAndUserId(keyword, userId);
+
+
+
 	}
 }

--- a/src/test/java/com/dadok/gaerval/domain/book/repository/BookRecentSearchSupportImplTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/repository/BookRecentSearchSupportImplTest.java
@@ -1,23 +1,19 @@
 package com.dadok.gaerval.domain.book.repository;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.jdbc.Sql;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.dadok.gaerval.domain.book.entity.BookRecentSearch;
 import com.dadok.gaerval.domain.user.entity.User;
 import com.dadok.gaerval.domain.user.repository.UserRepository;
 import com.dadok.gaerval.repository.CustomDataJpaTest;
 import com.dadok.gaerval.testutil.BookCommentObjectProvider;
-import com.dadok.gaerval.testutil.UserObjectProvider;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,7 +27,7 @@ class BookRecentSearchSupportImplTest {
 
 	@DisplayName("findRecentSearches - 유저 id로 검색어 찾는 쿼리 테스트")
 	@Test
-	void existsByBookIdAndUserId() {
+	void findRecentSearches() {
 		bookRecentSearchRepository.findRecentSearches(BookCommentObjectProvider.userId,
 			10L);
 	}

--- a/src/test/java/com/dadok/gaerval/domain/book/service/BookServiceTest.java
+++ b/src/test/java/com/dadok/gaerval/domain/book/service/BookServiceTest.java
@@ -216,7 +216,7 @@ class BookServiceTest {
 			.willReturn(bookResponses);
 
 		// when
-		BookResponses actualResponses = defaultBookService.findAllByKeyword(new BookSearchRequest(null, null, keyword), 1L);
+ 		BookResponses actualResponses = defaultBookService.findAllByKeyword(new BookSearchRequest(null, null, keyword, true), 1L);
 
 		// then
 		verify(externalBookApiOperations).searchBooks(keyword, 1, 10, SortingPolicy.ACCURACY.getName());
@@ -231,7 +231,7 @@ class BookServiceTest {
 	@ValueSource(strings = {"", " ", "!@#$", "키워드에@"})
 	void findAllByKeyword_WithInvalidKeyword_ReturnsEmptyList(String keyword) {
 		// when
-		BookResponses actualResponses = defaultBookService.findAllByKeyword(new BookSearchRequest(null, null, keyword), 1L);
+		BookResponses actualResponses = defaultBookService.findAllByKeyword(new BookSearchRequest(null, null, keyword, false), 1L);
 
 		// then
 		assertTrue(actualResponses.searchBookResponseList().isEmpty());
@@ -251,6 +251,6 @@ class BookServiceTest {
 
 		// when, then
 		assertThrows(BookApiNotAvailableException.class,
-			() -> defaultBookService.findAllByKeyword(new BookSearchRequest(null, null, keyword),1L));
+			() -> defaultBookService.findAllByKeyword(new BookSearchRequest(null, null, keyword, false),1L));
 	}
 }


### PR DESCRIPTION
<!--제목은 `[#이슈번호] 이슈 제목` 으로 작성한다.-->

### 🍀 목적
- 도서 검색 시 디바운싱으로 인한 원하지 않는 키워드가 저장되는 이슈
- 최근 키워드 저장 여부를 유동적으로 선택할 수 있도록 변경하기 위함

### 🌹 추가사항<!-- 있다면 적고 없다면 적지 않는다.-->
@minjongbaek 
- 키워드 저장 여부를 선택하는 request parameter 추가

### ☕ 변경사항<!-- 있다면 적고 없다면 적지 않는다.-->
@WooDaeHyun 
- 이와 더불어 최근 검색어 조회 API 호출 응답 순서와 항목을 변경했습니다. 생성시각이 아닌 수정시각을 표기하는 것이 자연스럽기도 하고 합리적이라고 생각했습니다.  UPSERT 방식으로 최근검색어가 저장되기 때문입니다. 
- 응답 순서는 수정시각 내림차순입니다. 


resolves #169 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
