### PR TITLE
[#171] 미로그인 사용자 책장 추천 API 결과에 중복되는 책 제거

### DIFF
--- a/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfSupportImpl.java
+++ b/src/main/java/com/dadok/gaerval/domain/bookshelf/repository/BookshelfSupportImpl.java
@@ -161,6 +161,7 @@ public class BookshelfSupportImpl implements BookshelfSupport {
 			.where(
 				bookshelf.id.in(searchBookshelfIn(searchBookshelfIds))
 			)
+			.groupBy(bookshelf.id, bookshelf.name, book.id, book.title, book.imageUrl)
 			.transform(
 				groupBy(bookshelf.id).list(constructor(BookShelfSummaryResponse.class,
 					bookshelf.id,


### PR DESCRIPTION
### 🍀 목적
책장 추천 API에서 중복된 책을 제거하여 결과를 반환하도록 합니다.

### ☕ 변경사항
- `findAllSuggestions` 메서드의 코드를 수정하여 중복된 책을 제거하도록 변경했어요.
- 이전에 발생한 중복 문제는 좋아요 개수를 보내주기 위해 집계함수 `count`를 사용했지만, `group by`를 사용하지 않아 발생했어요.
  - `transfrom`함수의 `groupBy`는 실제 sql문에 `group by`를 추가해주지 않아요.
  - `transfrom`함수의 `groupBy`는 `transform.groupBy`에 지정된 key를 기준으로 list를 만들 수 있도록 도와주는 기능이라고 해요.
- list를 만들기전에 `group by` 하도록 변경했어요.

### ❓ PR 포인트
- `BookshelfSupportImpl`의 다른 메소드들도 sql group by를 사용하고 있지 않아요. 현재 로그인 사용자의 결과에는 문제가 없지만, 변경이 필요할지 검토가 필요해요.

@youngjijang @minjongbaek 

resolves #171 